### PR TITLE
change main parse call to use .extension

### DIFF
--- a/examples/capture_parser/main.rs
+++ b/examples/capture_parser/main.rs
@@ -220,7 +220,7 @@ fn main() {
 	unsafe { PRINT_PACKETS = args.get(3).is_some(); }
 
 	let start = Instant::now();
-	let packet_count = if capture.extension().unwrap() == "zip" {
+	let packet_count = if !capture.is_dir() &&  capture.extension().unwrap() == "zip" {
 		parse(&capture, &mut cdclient)
 	} else {
 		visit_dirs(&capture, &mut cdclient, 0)

--- a/examples/capture_parser/main.rs
+++ b/examples/capture_parser/main.rs
@@ -220,7 +220,7 @@ fn main() {
 	unsafe { PRINT_PACKETS = args.get(3).is_some(); }
 
 	let start = Instant::now();
-	let packet_count = if capture.ends_with(".zip") {
+	let packet_count = if capture.extension().unwrap() == "zip" {
 		parse(&capture, &mut cdclient)
 	} else {
 		visit_dirs(&capture, &mut cdclient, 0)


### PR DESCRIPTION
Using ends_with does not recognize extensions:
https://doc.rust-lang.org/stable/std/path/struct.PathBuf.html#method.ends_with
But using the extension call does