### PR TITLE
fmt & clippy

### DIFF
--- a/examples/capture_parser/main.rs
+++ b/examples/capture_parser/main.rs
@@ -2,230 +2,287 @@ mod zip_context;
 
 use std::collections::HashMap;
 use std::env;
-use std::io::{BufReader, Result as Res};
 use std::fs;
 use std::fs::File;
+use std::io::{BufReader, Result as Res};
 use std::path::Path;
 use std::time::Instant;
 
+use self::zip_context::ZipContext;
 use lu_packets::{
-	auth::server::Message as AuthServerMessage,
-	world::Lot,
-	world::server::Message as WorldServerMessage,
-	world::client::Message as WorldClientMessage,
+    auth::server::Message as AuthServerMessage, world::client::Message as WorldClientMessage,
+    world::server::Message as WorldServerMessage, world::Lot,
 };
 use rusqlite::{params, Connection};
 use zip::ZipArchive;
-use self::zip_context::ZipContext;
 
 static mut PRINT_PACKETS: bool = false;
 
 pub struct Cdclient {
-	conn: Connection,
-	comp_cache: HashMap<Lot, Vec<u32>>,
+    conn: Connection,
+    comp_cache: HashMap<Lot, Vec<u32>>,
 }
 
 impl Cdclient {
-	fn get_comps(&mut self, lot: Lot) -> &Vec<u32> {
-		if !self.comp_cache.contains_key(&lot) {
-			let mut stmt = self.conn.prepare("select component_type from componentsregistry where id = ?").unwrap();
-			let rows: Vec<_> = stmt.query_map(params![lot], |row| row.get(0)).unwrap().map(|x| x.unwrap()).collect();
-			self.comp_cache.insert(lot, rows);
-		}
-		&self.comp_cache.get(&lot).unwrap()
-	}
+    fn get_comps(&mut self, lot: Lot) -> &Vec<u32> {
+        if !self.comp_cache.contains_key(&lot) {
+            let mut stmt = self
+                .conn
+                .prepare("select component_type from componentsregistry where id = ?")
+                .unwrap();
+            let rows: Vec<_> = stmt
+                .query_map(params![lot], |row| row.get(0))
+                .unwrap()
+                .map(|x| x.unwrap())
+                .collect();
+            self.comp_cache.insert(lot, rows);
+        }
+        &self.comp_cache.get(&lot).unwrap()
+    }
 }
 
 fn visit_dirs(dir: &Path, cdclient: &mut Cdclient, level: usize) -> Res<usize> {
-	let mut packet_count = 0;
-	if dir.is_dir() {
-		for entry in fs::read_dir(dir)? {
-			let entry = entry?;
-			let path = entry.path();
-			packet_count += if path.is_dir() { visit_dirs(&path, cdclient, level+1) } else { parse(&path, cdclient) }?;
-			println!("packet count = {:>level$}", packet_count, level=level*6);
-		}
-	}
-	Ok(packet_count)
+    let mut packet_count = 0;
+    if dir.is_dir() {
+        for entry in fs::read_dir(dir)? {
+            let entry = entry?;
+            let path = entry.path();
+            packet_count += if path.is_dir() {
+                visit_dirs(&path, cdclient, level + 1)
+            } else {
+                parse(&path, cdclient)
+            }?;
+            println!("packet count = {:>level$}", packet_count, level = level * 6);
+        }
+    }
+    Ok(packet_count)
 }
 
 fn parse(path: &Path, cdclient: &mut Cdclient) -> Res<usize> {
-	use endio::LERead;
+    use endio::LERead;
 
-	if path.extension().unwrap() != "zip" { return Ok(0); }
+    if path.extension().unwrap() != "zip" {
+        return Ok(0);
+    }
 
-	let src = BufReader::new(File::open(path).unwrap());
-	let mut zip = ZipArchive::new(src).unwrap();
-	let mut comps = HashMap::new();
-	let mut i = 0;
-	let mut packet_count = 0;
-	while i < zip.len() {
-		let mut file = zip.by_index(i).unwrap();
-		if file.name().contains("of") {
-			i += 1; continue;
-		}
-		if file.name().contains("[53-01-") {
-			let msg: AuthServerMessage = file.read().expect(&format!("Zip: {}, Filename: {}, {} bytes", path.to_str().unwrap(), file.name(), file.size()));
-			if unsafe { PRINT_PACKETS } {
-				dbg!(msg);
-			}
-			packet_count += 1
-		} else if file.name().contains("[53-04-")
-			&& !file.name().contains("[53-04-00-16]")
-			&& !file.name().contains("[e6-00]")
-			&& !file.name().contains("[6b-03]")
-			&& !file.name().contains("[16-04]")
-			&& !file.name().contains("[49-04]")
-			&& !file.name().contains("[ad-04]")
-			&& !file.name().contains("[1c-05]")
-			&& !file.name().contains("[230]")
-			&& !file.name().contains("[875]")
-			&& !file.name().contains("[1046]")
-			&& !file.name().contains("[1097]")
-			&& !file.name().contains("[1197]")
-			&& !file.name().contains("[1308]")
-		{
-			let msg: WorldServerMessage = file.read().expect(&format!("Zip: {}, Filename: {}, {} bytes", path.to_str().unwrap(), file.name(), file.size()));
-			if unsafe { PRINT_PACKETS } {
-				dbg!(&msg);
-			}
-			packet_count += 1;
-		} else if file.name().contains("[53-02-") || (file.name().contains("[53-05-")
-		&& !file.name().contains("[53-05-00-00]")
-		&& !file.name().contains("[53-05-00-15]")
-		&& !file.name().contains("[53-05-00-31]")
-		&& !file.name().contains("[76-00]")
-		&& !file.name().contains("[e6-00]")
-		&& !file.name().contains("[ff-00]")
-		&& !file.name().contains("[a1-01]")
-		&& !file.name().contains("[7f-02]")
-		&& !file.name().contains("[a3-02]")
-		&& !file.name().contains("[cc-02]")
-		&& !file.name().contains("[35-03]")
-		&& !file.name().contains("[36-03]")
-		&& !file.name().contains("[4d-03]")
-		&& !file.name().contains("[6d-03]")
-		&& !file.name().contains("[91-03]")
-		&& !file.name().contains("[1a-05]")
-		&& !file.name().contains("[e6-05]")
-		&& !file.name().contains("[16-06]")
-		&& !file.name().contains("[1c-06]")
-		&& !file.name().contains("[6f-06]")
-		&& !file.name().contains("[70-06]")
-		&& !file.name().contains("[118]")
-		&& !file.name().contains("[230]")
-		&& !file.name().contains("[255]")
-		&& !file.name().contains("[417]")
-		&& !file.name().contains("[639]")
-		&& !file.name().contains("[675]")
-		&& !file.name().contains("[716]")
-		&& !file.name().contains("[821]")
-		&& !file.name().contains("[822]")
-		&& !file.name().contains("[845]")
-		&& !file.name().contains("[877]")
-		&& !file.name().contains("[913]")
-		&& !file.name().contains("[1306]")
-		&& !file.name().contains("[1510]")
-		&& !file.name().contains("[1558]")
-		&& !file.name().contains("[1564]")
-		&& !file.name().contains("[1647]")
-		&& !file.name().contains("[1648]"))
-		|| (file.name().contains("[24]")
-		&& !file.name().contains("(2248)")
-		&& !file.name().contains("(2365)")
-		&& !file.name().contains("(4734)")
-		&& !file.name().contains("(4930)")
-		&& !file.name().contains("(4955)")
-		&& !file.name().contains("(4967)")
-		&& !file.name().contains("(4990)")
-		&& !file.name().contains("(5635)")
-		&& !file.name().contains("(5651)")
-		&& !file.name().contains("(5652)")
-		&& !file.name().contains("(5903)")
-		&& !file.name().contains("(5904)")
-		&& !file.name().contains("(5958)")
-		&& !file.name().contains("(6007)")
-		&& !file.name().contains("(6010)")
-		&& !file.name().contains("(6097)")
-		&& !file.name().contains("(6209)")
-		&& !file.name().contains("(6267)")
-		&& !file.name().contains("(6289)")
-		&& !file.name().contains("(6290)")
-		&& !file.name().contains("(6319)")
-		&& !file.name().contains("(7001)")
-		&& !file.name().contains("(7100)")
-		&& !file.name().contains("(7282)")
-		&& !file.name().contains("(7796)")
-		&& !file.name().contains("(8304)")
-		&& !file.name().contains("(8575)")
-		&& !file.name().contains("(9741)")
-		&& !file.name().contains("(10039)")
-		&& !file.name().contains("(10042)")
-		&& !file.name().contains("(10046)")
-		&& !file.name().contains("(10055)")
-		&& !file.name().contains("(10097)")
-		&& !file.name().contains("(12916)")
-		&& !file.name().contains("(13773)")
-		&& !file.name().contains("(14376)")
-		&& !file.name().contains("(14447)")
-		&& !file.name().contains("(14449)")
-		&& !file.name().contains("(14476)")
-		&& !file.name().contains("(14477)")
-		&& !file.name().contains("(14505)")
-		&& !file.name().contains("(14510)")
-		&& !file.name().contains("(14539)")
-		&& !file.name().contains("(14540)")
-		&& !file.name().contains("(14541)")
-		&& !file.name().contains("(14542)")
-		&& !file.name().contains("(14543)")
-		&& !file.name().contains("(14544)")
-		&& !file.name().contains("(14545)")
-		&& !file.name().contains("(14546)")
-		&& !file.name().contains("(14547)"))
-		|| file.name().contains("[27]")
-		{
-			let mut ctx = ZipContext { zip: file, comps: &mut comps, cdclient, assert_fully_read: true };
-			let msg: WorldClientMessage = ctx.read().expect(&format!("Zip: {}, Filename: {}, {} bytes", path.to_str().unwrap(), ctx.zip.name(), ctx.zip.size()));
-			file = ctx.zip;
-			if unsafe { PRINT_PACKETS } {
-				dbg!(&msg);
-			}
-			packet_count += 1;
+    let src = BufReader::new(File::open(path).unwrap());
+    let mut zip = ZipArchive::new(src).unwrap();
+    let mut comps = HashMap::new();
+    let mut i = 0;
+    let mut packet_count = 0;
+    while i < zip.len() {
+        let mut file = zip.by_index(i).unwrap();
+        if file.name().contains("of") {
+            i += 1;
+            continue;
+        }
+        if file.name().contains("[53-01-") {
+            let msg: AuthServerMessage = file.read().expect(&format!(
+                "Zip: {}, Filename: {}, {} bytes",
+                path.to_str().unwrap(),
+                file.name(),
+                file.size()
+            ));
+            if unsafe { PRINT_PACKETS } {
+                dbg!(msg);
+            }
+            packet_count += 1
+        } else if file.name().contains("[53-04-")
+            && !file.name().contains("[53-04-00-16]")
+            && !file.name().contains("[e6-00]")
+            && !file.name().contains("[6b-03]")
+            && !file.name().contains("[16-04]")
+            && !file.name().contains("[49-04]")
+            && !file.name().contains("[ad-04]")
+            && !file.name().contains("[1c-05]")
+            && !file.name().contains("[230]")
+            && !file.name().contains("[875]")
+            && !file.name().contains("[1046]")
+            && !file.name().contains("[1097]")
+            && !file.name().contains("[1197]")
+            && !file.name().contains("[1308]")
+        {
+            let msg: WorldServerMessage = file.read().expect(&format!(
+                "Zip: {}, Filename: {}, {} bytes",
+                path.to_str().unwrap(),
+                file.name(),
+                file.size()
+            ));
+            if unsafe { PRINT_PACKETS } {
+                dbg!(&msg);
+            }
+            packet_count += 1;
+        } else if file.name().contains("[53-02-")
+            || (file.name().contains("[53-05-")
+                && !file.name().contains("[53-05-00-00]")
+                && !file.name().contains("[53-05-00-15]")
+                && !file.name().contains("[53-05-00-31]")
+                && !file.name().contains("[76-00]")
+                && !file.name().contains("[e6-00]")
+                && !file.name().contains("[ff-00]")
+                && !file.name().contains("[a1-01]")
+                && !file.name().contains("[7f-02]")
+                && !file.name().contains("[a3-02]")
+                && !file.name().contains("[cc-02]")
+                && !file.name().contains("[35-03]")
+                && !file.name().contains("[36-03]")
+                && !file.name().contains("[4d-03]")
+                && !file.name().contains("[6d-03]")
+                && !file.name().contains("[91-03]")
+                && !file.name().contains("[1a-05]")
+                && !file.name().contains("[e6-05]")
+                && !file.name().contains("[16-06]")
+                && !file.name().contains("[1c-06]")
+                && !file.name().contains("[6f-06]")
+                && !file.name().contains("[70-06]")
+                && !file.name().contains("[118]")
+                && !file.name().contains("[230]")
+                && !file.name().contains("[255]")
+                && !file.name().contains("[417]")
+                && !file.name().contains("[639]")
+                && !file.name().contains("[675]")
+                && !file.name().contains("[716]")
+                && !file.name().contains("[821]")
+                && !file.name().contains("[822]")
+                && !file.name().contains("[845]")
+                && !file.name().contains("[877]")
+                && !file.name().contains("[913]")
+                && !file.name().contains("[1306]")
+                && !file.name().contains("[1510]")
+                && !file.name().contains("[1558]")
+                && !file.name().contains("[1564]")
+                && !file.name().contains("[1647]")
+                && !file.name().contains("[1648]"))
+            || (file.name().contains("[24]")
+                && !file.name().contains("(2248)")
+                && !file.name().contains("(2365)")
+                && !file.name().contains("(4734)")
+                && !file.name().contains("(4930)")
+                && !file.name().contains("(4955)")
+                && !file.name().contains("(4967)")
+                && !file.name().contains("(4990)")
+                && !file.name().contains("(5635)")
+                && !file.name().contains("(5651)")
+                && !file.name().contains("(5652)")
+                && !file.name().contains("(5903)")
+                && !file.name().contains("(5904)")
+                && !file.name().contains("(5958)")
+                && !file.name().contains("(6007)")
+                && !file.name().contains("(6010)")
+                && !file.name().contains("(6097)")
+                && !file.name().contains("(6209)")
+                && !file.name().contains("(6267)")
+                && !file.name().contains("(6289)")
+                && !file.name().contains("(6290)")
+                && !file.name().contains("(6319)")
+                && !file.name().contains("(7001)")
+                && !file.name().contains("(7100)")
+                && !file.name().contains("(7282)")
+                && !file.name().contains("(7796)")
+                && !file.name().contains("(8304)")
+                && !file.name().contains("(8575)")
+                && !file.name().contains("(9741)")
+                && !file.name().contains("(10039)")
+                && !file.name().contains("(10042)")
+                && !file.name().contains("(10046)")
+                && !file.name().contains("(10055)")
+                && !file.name().contains("(10097)")
+                && !file.name().contains("(12916)")
+                && !file.name().contains("(13773)")
+                && !file.name().contains("(14376)")
+                && !file.name().contains("(14447)")
+                && !file.name().contains("(14449)")
+                && !file.name().contains("(14476)")
+                && !file.name().contains("(14477)")
+                && !file.name().contains("(14505)")
+                && !file.name().contains("(14510)")
+                && !file.name().contains("(14539)")
+                && !file.name().contains("(14540)")
+                && !file.name().contains("(14541)")
+                && !file.name().contains("(14542)")
+                && !file.name().contains("(14543)")
+                && !file.name().contains("(14544)")
+                && !file.name().contains("(14545)")
+                && !file.name().contains("(14546)")
+                && !file.name().contains("(14547)"))
+            || file.name().contains("[27]")
+        {
+            let mut ctx = ZipContext {
+                zip: file,
+                comps: &mut comps,
+                cdclient,
+                assert_fully_read: true,
+            };
+            let msg: WorldClientMessage = ctx.read().expect(&format!(
+                "Zip: {}, Filename: {}, {} bytes",
+                path.to_str().unwrap(),
+                ctx.zip.name(),
+                ctx.zip.size()
+            ));
+            file = ctx.zip;
+            if unsafe { PRINT_PACKETS } {
+                dbg!(&msg);
+            }
+            packet_count += 1;
 
-			if ctx.assert_fully_read {
-				// assert fully read
-				let mut rest = vec![];
-				std::io::Read::read_to_end(&mut file, &mut rest).unwrap();
-				assert_eq!(rest, vec![], "Zip: {}, Filename: {}, {} bytes", path.to_str().unwrap(), file.name(), file.size());
-			}
-			i += 1; continue
-		} else { i += 1; continue }
-		// assert fully read
-		let mut rest = vec![];
-		std::io::Read::read_to_end(&mut file, &mut rest).unwrap();
-		assert_eq!(rest, vec![], "Zip: {}, Filename: {}, {} bytes", path.to_str().unwrap(), file.name(), file.size());
-		i += 1;
-	}
-	Ok(packet_count)
+            if ctx.assert_fully_read {
+                // assert fully read
+                let mut rest = vec![];
+                std::io::Read::read_to_end(&mut file, &mut rest).unwrap();
+                assert_eq!(
+                    rest,
+                    vec![],
+                    "Zip: {}, Filename: {}, {} bytes",
+                    path.to_str().unwrap(),
+                    file.name(),
+                    file.size()
+                );
+            }
+            i += 1;
+            continue;
+        } else {
+            i += 1;
+            continue;
+        }
+        // assert fully read
+        let mut rest = vec![];
+        std::io::Read::read_to_end(&mut file, &mut rest).unwrap();
+        assert_eq!(
+            rest,
+            vec![],
+            "Zip: {}, Filename: {}, {} bytes",
+            path.to_str().unwrap(),
+            file.name(),
+            file.size()
+        );
+        i += 1;
+    }
+    Ok(packet_count)
 }
 
 fn main() {
-	let args: Vec<String> = env::args().collect();
-	if args.len() < 3 {
-		println!("Usage: capture_parser capture_path cdclient_path --print_packets");
-		return;
-	}
-	let capture = fs::canonicalize(&args[1]).unwrap();
-	let mut cdclient = Cdclient { conn: Connection::open(&args[2]).unwrap(), comp_cache: HashMap::new() };
-	unsafe { PRINT_PACKETS = args.get(3).is_some(); }
+    let args: Vec<String> = env::args().collect();
+    if args.len() < 3 {
+        println!("Usage: capture_parser capture_path cdclient_path --print_packets");
+        return;
+    }
+    let capture = fs::canonicalize(&args[1]).unwrap();
+    let mut cdclient = Cdclient {
+        conn: Connection::open(&args[2]).unwrap(),
+        comp_cache: HashMap::new(),
+    };
+    unsafe {
+        PRINT_PACKETS = args.get(3).is_some();
+    }
 
-	let start = Instant::now();
-	let packet_count = if !capture.is_dir() &&  capture.extension().unwrap() == "zip" {
-		parse(&capture, &mut cdclient)
-	} else {
-		visit_dirs(&capture, &mut cdclient, 0)
-	}.unwrap();
-	println!();
-	println!("Number of parsed packets: {}", packet_count);
-	println!("Time taken: {:?}", start.elapsed());
+    let start = Instant::now();
+    let packet_count = if !capture.is_dir() && capture.extension().unwrap() == "zip" {
+        parse(&capture, &mut cdclient)
+    } else {
+        visit_dirs(&capture, &mut cdclient, 0)
+    }
+    .unwrap();
+    println!();
+    println!("Number of parsed packets: {}", packet_count);
+    println!("Time taken: {:?}", start.elapsed());
 }

--- a/examples/capture_parser/zip_context.rs
+++ b/examples/capture_parser/zip_context.rs
@@ -3,233 +3,409 @@ use std::io::Result as Res;
 
 use endio_bit::BEBitReader;
 use lu_packets::{
-	lu,
-	raknet::client::replica::{
-		ComponentConstruction, ComponentSerialization, ReplicaContext,
-		achievement_vendor::{AchievementVendorConstruction, AchievementVendorSerialization},
-		base_combat_ai::{BaseCombatAiConstruction, BaseCombatAiSerialization},
-		bbb::{BbbConstruction, BbbSerialization},
-		bouncer::{BouncerConstruction, BouncerSerialization},
-		buff::BuffConstruction,
-		character::{CharacterConstruction, CharacterSerialization},
-		collectible::{CollectibleConstruction, CollectibleSerialization},
-		controllable_physics::{ControllablePhysicsConstruction, ControllablePhysicsSerialization},
-		donation_vendor::{DonationVendorConstruction, DonationVendorSerialization},
-		destroyable::{DestroyableConstruction, DestroyableSerialization},
-		fx::FxConstruction,
-		inventory::{InventoryConstruction, InventorySerialization},
-		item::{ItemConstruction, ItemSerialization},
-		level_progression::{LevelProgressionConstruction, LevelProgressionSerialization},
-		lup_exhibit::{LupExhibitConstruction, LupExhibitSerialization},
-		module_assembly::ModuleAssemblyConstruction,
-		moving_platform::{MovingPlatformConstruction, MovingPlatformSerialization},
-		mutable_model_behavior::{MutableModelBehaviorConstruction, MutableModelBehaviorSerialization},
-		phantom_physics::{PhantomPhysicsConstruction, PhantomPhysicsSerialization},
-		player_forced_movement::{PlayerForcedMovementConstruction, PlayerForcedMovementSerialization},
-		pet::{PetConstruction, PetSerialization},
-		possessable::{PossessableConstruction, PossessableSerialization},
-		possession_control::{PossessionControlConstruction, PossessionControlSerialization},
-		quickbuild::{QuickbuildConstruction, QuickbuildSerialization},
-		racing_control::{RacingControlConstruction, RacingControlSerialization},
-		rigid_body_phantom_physics::{RigidBodyPhantomPhysicsConstruction, RigidBodyPhantomPhysicsSerialization},
-		script::ScriptConstruction,
-		scripted_activity::{ScriptedActivityConstruction, ScriptedActivitySerialization},
-		shooting_gallery::{ShootingGalleryConstruction, ShootingGallerySerialization},
-		simple_physics::{SimplePhysicsConstruction, SimplePhysicsSerialization},
-		skill::SkillConstruction,
-		switch::{SwitchConstruction, SwitchSerialization},
-		vehicle_physics::{VehiclePhysicsConstruction, VehiclePhysicsSerialization},
-		vendor::{VendorConstruction, VendorSerialization},
-	},
-	world::{Lot, LuNameValue, LnvValue},
+    lu,
+    raknet::client::replica::{
+        achievement_vendor::{AchievementVendorConstruction, AchievementVendorSerialization},
+        base_combat_ai::{BaseCombatAiConstruction, BaseCombatAiSerialization},
+        bbb::{BbbConstruction, BbbSerialization},
+        bouncer::{BouncerConstruction, BouncerSerialization},
+        buff::BuffConstruction,
+        character::{CharacterConstruction, CharacterSerialization},
+        collectible::{CollectibleConstruction, CollectibleSerialization},
+        controllable_physics::{ControllablePhysicsConstruction, ControllablePhysicsSerialization},
+        destroyable::{DestroyableConstruction, DestroyableSerialization},
+        donation_vendor::{DonationVendorConstruction, DonationVendorSerialization},
+        fx::FxConstruction,
+        inventory::{InventoryConstruction, InventorySerialization},
+        item::{ItemConstruction, ItemSerialization},
+        level_progression::{LevelProgressionConstruction, LevelProgressionSerialization},
+        lup_exhibit::{LupExhibitConstruction, LupExhibitSerialization},
+        module_assembly::ModuleAssemblyConstruction,
+        moving_platform::{MovingPlatformConstruction, MovingPlatformSerialization},
+        mutable_model_behavior::{
+            MutableModelBehaviorConstruction, MutableModelBehaviorSerialization,
+        },
+        pet::{PetConstruction, PetSerialization},
+        phantom_physics::{PhantomPhysicsConstruction, PhantomPhysicsSerialization},
+        player_forced_movement::{
+            PlayerForcedMovementConstruction, PlayerForcedMovementSerialization,
+        },
+        possessable::{PossessableConstruction, PossessableSerialization},
+        possession_control::{PossessionControlConstruction, PossessionControlSerialization},
+        quickbuild::{QuickbuildConstruction, QuickbuildSerialization},
+        racing_control::{RacingControlConstruction, RacingControlSerialization},
+        rigid_body_phantom_physics::{
+            RigidBodyPhantomPhysicsConstruction, RigidBodyPhantomPhysicsSerialization,
+        },
+        script::ScriptConstruction,
+        scripted_activity::{ScriptedActivityConstruction, ScriptedActivitySerialization},
+        shooting_gallery::{ShootingGalleryConstruction, ShootingGallerySerialization},
+        simple_physics::{SimplePhysicsConstruction, SimplePhysicsSerialization},
+        skill::SkillConstruction,
+        switch::{SwitchConstruction, SwitchSerialization},
+        vehicle_physics::{VehiclePhysicsConstruction, VehiclePhysicsSerialization},
+        vendor::{VendorConstruction, VendorSerialization},
+        ComponentConstruction, ComponentSerialization, ReplicaContext,
+    },
+    world::{LnvValue, Lot, LuNameValue},
 };
 use zip::read::ZipFile;
 
 use super::Cdclient;
 
-const COMP_ORDER: [u32; 35] = [108, 61, 1, 30, 20, 3, 40, 98, 7, 110, 109, 106, 4, 26, 17, 5, 9, 60, 11, 48, 25, 16, 100, 102, 19, 39, 23, 75, 42, 6, 49, 2, 44, 71, 107];
+const COMP_ORDER: [u32; 35] = [
+    108, 61, 1, 30, 20, 3, 40, 98, 7, 110, 109, 106, 4, 26, 17, 5, 9, 60, 11, 48, 25, 16, 100, 102,
+    19, 39, 23, 75, 42, 6, 49, 2, 44, 71, 107,
+];
 
 pub struct ZipContext<'a> {
-	pub zip: ZipFile<'a>,
-	pub comps: &'a mut HashMap<u16, Vec<u32>>,
-	pub cdclient: &'a mut Cdclient,
-	pub assert_fully_read: bool,
+    pub zip: ZipFile<'a>,
+    pub comps: &'a mut HashMap<u16, Vec<u32>>,
+    pub cdclient: &'a mut Cdclient,
+    pub assert_fully_read: bool,
 }
 
 impl ZipContext<'_> {
-	fn apply_whitelist(comps: &mut Vec<u32>, config: &Option<LuNameValue>) {
-		if let Some(conf) = config {
-			if let Some(LnvValue::I32(1)) = conf.get(&lu!("componentWhitelist")) {
-				comps.retain(|&x|
-					match x  {
-						1 | 2 | 3 | 7 | 10 | 11 | 24 | 42 => true,
-						_ => false,
-					}
-				);
-			}
-		}
-	}
+    fn apply_whitelist(comps: &mut Vec<u32>, config: &Option<LuNameValue>) {
+        if let Some(conf) = config {
+            if let Some(LnvValue::I32(1)) = conf.get(&lu!("componentWhitelist")) {
+                comps.retain(|&x| match x {
+                    1 | 2 | 3 | 7 | 10 | 11 | 24 | 42 => true,
+                    _ => false,
+                });
+            }
+        }
+    }
 
-	fn apply_config_overrides(comps: &mut Vec<u32>, config: &Option<LuNameValue>) {
-		if comps.contains(&42) {
-			if let Some(conf) = config {
-				if conf.contains_key(&lu!("modelBehaviors")) {
-					if let Some(LnvValue::I32(m_type)) = conf.get(&lu!("modelType")) {
-						let new_phys = if *m_type == 0 { 1 } else { 3 };
-						if let Some(phys_index) = comps.iter().position(|&x| x == 1 || x == 3) {
-							comps[phys_index] = new_phys;
-						} else {
-							comps.push(new_phys);
-						}
-						return;
-					}
-				}
-			}
-			if comps.iter().position(|&x| x == 1 || x == 3).is_none() {
-				comps.push(3);
-			}
-		}
-	}
+    fn apply_config_overrides(comps: &mut Vec<u32>, config: &Option<LuNameValue>) {
+        if comps.contains(&42) {
+            if let Some(conf) = config {
+                if conf.contains_key(&lu!("modelBehaviors")) {
+                    if let Some(LnvValue::I32(m_type)) = conf.get(&lu!("modelType")) {
+                        let new_phys = if *m_type == 0 { 1 } else { 3 };
+                        if let Some(phys_index) = comps.iter().position(|&x| x == 1 || x == 3) {
+                            comps[phys_index] = new_phys;
+                        } else {
+                            comps.push(new_phys);
+                        }
+                        return;
+                    }
+                }
+            }
+            if comps.iter().position(|&x| x == 1 || x == 3).is_none() {
+                comps.push(3);
+            }
+        }
+    }
 
-	fn apply_component_overrides(comps: &Vec<u32>, final_comps: &mut Vec<u32>) {
-		for comp in comps {
-			// special case: utter bodge
-			match comp {
-				2  => { final_comps.push(44); }
-				4  => { final_comps.push(110); final_comps.push(109); final_comps.push(106); }
-				7  => { final_comps.push(98); }
-				23 | 48 => {
-					if !final_comps.contains(&7) {
-						final_comps.push(7);
-					}
-				}
-				_ => {},
-			}
-			final_comps.push(*comp);
-		}
-		// special case: utter bodge
-		if final_comps.contains(&26) {
-			final_comps.remove(final_comps.iter().position(|&x| x == 11).unwrap());
-			final_comps.remove(final_comps.iter().position(|&x| x == 42).unwrap());
-		}
-	}
+    fn apply_component_overrides(comps: &Vec<u32>, final_comps: &mut Vec<u32>) {
+        for comp in comps {
+            // special case: utter bodge
+            match comp {
+                2 => {
+                    final_comps.push(44);
+                }
+                4 => {
+                    final_comps.push(110);
+                    final_comps.push(109);
+                    final_comps.push(106);
+                }
+                7 => {
+                    final_comps.push(98);
+                }
+                23 | 48 => {
+                    if !final_comps.contains(&7) {
+                        final_comps.push(7);
+                    }
+                }
+                _ => {}
+            }
+            final_comps.push(*comp);
+        }
+        // special case: utter bodge
+        if final_comps.contains(&26) {
+            final_comps.remove(final_comps.iter().position(|&x| x == 11).unwrap());
+            final_comps.remove(final_comps.iter().position(|&x| x == 42).unwrap());
+        }
+    }
 
-	fn map_constrs<R: std::io::Read>(comps: &Vec<u32>) -> Vec<fn(&mut BEBitReader<R>) -> Res<Box<dyn ComponentConstruction>>> {
-		use endio::Deserialize;
+    fn map_constrs<R: std::io::Read>(
+        comps: &Vec<u32>,
+    ) -> Vec<fn(&mut BEBitReader<R>) -> Res<Box<dyn ComponentConstruction>>> {
+        use endio::Deserialize;
 
-		let mut constrs: Vec<fn(&mut BEBitReader<R>) -> Res<Box<dyn ComponentConstruction>>> = vec![];
-		for comp in comps {
-			match comp {
-				1  =>  { constrs.push(|x| Ok(Box::new(ControllablePhysicsConstruction::deserialize(x)?))); }
-				3  =>  { constrs.push(|x| Ok(Box::new(SimplePhysicsConstruction::deserialize(x)?))); }
-				4  =>  { constrs.push(|x| Ok(Box::new(CharacterConstruction::deserialize(x)?))); }
-				5  =>  { constrs.push(|x| Ok(Box::new(ScriptConstruction::deserialize(x)?))); }
-				6  =>  { constrs.push(|x| Ok(Box::new(BouncerConstruction::deserialize(x)?))); }
-				7  =>  { constrs.push(|x| Ok(Box::new(DestroyableConstruction::deserialize(x)?))); }
-				9  =>  { constrs.push(|x| Ok(Box::new(SkillConstruction::deserialize(x)?))); }
-				11 =>  { constrs.push(|x| Ok(Box::new(ItemConstruction::deserialize(x)?))); }
-				16 =>  { constrs.push(|x| Ok(Box::new(VendorConstruction::deserialize(x)?))); }
-				17 =>  { constrs.push(|x| Ok(Box::new(InventoryConstruction::deserialize(x)?))); }
-				19 =>  { constrs.push(|x| Ok(Box::new(ShootingGalleryConstruction::deserialize(x)?))); }
-				20 =>  { constrs.push(|x| Ok(Box::new(RigidBodyPhantomPhysicsConstruction::deserialize(x)?))); }
-				23 =>  { constrs.push(|x| Ok(Box::new(CollectibleConstruction::deserialize(x)?))); }
-				25 =>  { constrs.push(|x| Ok(Box::new(MovingPlatformConstruction::deserialize(x)?))); }
-				26 =>  { constrs.push(|x| Ok(Box::new(PetConstruction::deserialize(x)?))); }
-				30 =>  { constrs.push(|x| Ok(Box::new(VehiclePhysicsConstruction::deserialize(x)?))); }
-				39 =>  { constrs.push(|x| Ok(Box::new(ScriptedActivityConstruction::deserialize(x)?))); }
-				40 =>  { constrs.push(|x| Ok(Box::new(PhantomPhysicsConstruction::deserialize(x)?))); }
-				42 =>  { constrs.push(|x| Ok(Box::new(MutableModelBehaviorConstruction::deserialize(x)?))); }
-				44 =>  { constrs.push(|x| Ok(Box::new(FxConstruction::deserialize(x)?))); }
-				48 =>  { constrs.push(|x| Ok(Box::new(QuickbuildConstruction::deserialize(x)?))); }
-				49 =>  { constrs.push(|x| Ok(Box::new(SwitchConstruction::deserialize(x)?))); }
-				60 =>  { constrs.push(|x| Ok(Box::new(BaseCombatAiConstruction::deserialize(x)?))); }
-				61 =>  { constrs.push(|x| Ok(Box::new(ModuleAssemblyConstruction::deserialize(x)?))); }
-				71 =>  { constrs.push(|x| Ok(Box::new(RacingControlConstruction::deserialize(x)?))); }
-				75 =>  { constrs.push(|x| Ok(Box::new(LupExhibitConstruction::deserialize(x)?))); }
-				98 =>  { constrs.push(|x| Ok(Box::new(BuffConstruction::deserialize(x)?))); }
-				100 => { constrs.push(|x| Ok(Box::new(DonationVendorConstruction::deserialize(x)?))); }
-				102 => { constrs.push(|x| Ok(Box::new(AchievementVendorConstruction::deserialize(x)?))); }
-				106 => { constrs.push(|x| Ok(Box::new(PlayerForcedMovementConstruction::deserialize(x)?))); }
-				107 => { constrs.push(|x| Ok(Box::new(BbbConstruction::deserialize(x)?))); }
-				108 => { constrs.push(|x| Ok(Box::new(PossessableConstruction::deserialize(x)?))); }
-				109 => { constrs.push(|x| Ok(Box::new(LevelProgressionConstruction::deserialize(x)?))); }
-				110 => { constrs.push(|x| Ok(Box::new(PossessionControlConstruction::deserialize(x)?))); }
-				2 | 12 | 24 | 27 | 31 | 35 | 36 | 43 | 45 | 55 | 56 | 57 | 64 | 65 | 67 | 68 | 73 | 74 | 78 | 95 | 104 | 113 | 114 => {},
-				x => panic!("{}", x),
-			}
-		}
-		constrs
-	}
+        let mut constrs: Vec<fn(&mut BEBitReader<R>) -> Res<Box<dyn ComponentConstruction>>> =
+            vec![];
+        for comp in comps {
+            match comp {
+                1 => {
+                    constrs
+                        .push(|x| Ok(Box::new(ControllablePhysicsConstruction::deserialize(x)?)));
+                }
+                3 => {
+                    constrs.push(|x| Ok(Box::new(SimplePhysicsConstruction::deserialize(x)?)));
+                }
+                4 => {
+                    constrs.push(|x| Ok(Box::new(CharacterConstruction::deserialize(x)?)));
+                }
+                5 => {
+                    constrs.push(|x| Ok(Box::new(ScriptConstruction::deserialize(x)?)));
+                }
+                6 => {
+                    constrs.push(|x| Ok(Box::new(BouncerConstruction::deserialize(x)?)));
+                }
+                7 => {
+                    constrs.push(|x| Ok(Box::new(DestroyableConstruction::deserialize(x)?)));
+                }
+                9 => {
+                    constrs.push(|x| Ok(Box::new(SkillConstruction::deserialize(x)?)));
+                }
+                11 => {
+                    constrs.push(|x| Ok(Box::new(ItemConstruction::deserialize(x)?)));
+                }
+                16 => {
+                    constrs.push(|x| Ok(Box::new(VendorConstruction::deserialize(x)?)));
+                }
+                17 => {
+                    constrs.push(|x| Ok(Box::new(InventoryConstruction::deserialize(x)?)));
+                }
+                19 => {
+                    constrs.push(|x| Ok(Box::new(ShootingGalleryConstruction::deserialize(x)?)));
+                }
+                20 => {
+                    constrs.push(|x| {
+                        Ok(Box::new(RigidBodyPhantomPhysicsConstruction::deserialize(
+                            x,
+                        )?))
+                    });
+                }
+                23 => {
+                    constrs.push(|x| Ok(Box::new(CollectibleConstruction::deserialize(x)?)));
+                }
+                25 => {
+                    constrs.push(|x| Ok(Box::new(MovingPlatformConstruction::deserialize(x)?)));
+                }
+                26 => {
+                    constrs.push(|x| Ok(Box::new(PetConstruction::deserialize(x)?)));
+                }
+                30 => {
+                    constrs.push(|x| Ok(Box::new(VehiclePhysicsConstruction::deserialize(x)?)));
+                }
+                39 => {
+                    constrs.push(|x| Ok(Box::new(ScriptedActivityConstruction::deserialize(x)?)));
+                }
+                40 => {
+                    constrs.push(|x| Ok(Box::new(PhantomPhysicsConstruction::deserialize(x)?)));
+                }
+                42 => {
+                    constrs
+                        .push(|x| Ok(Box::new(MutableModelBehaviorConstruction::deserialize(x)?)));
+                }
+                44 => {
+                    constrs.push(|x| Ok(Box::new(FxConstruction::deserialize(x)?)));
+                }
+                48 => {
+                    constrs.push(|x| Ok(Box::new(QuickbuildConstruction::deserialize(x)?)));
+                }
+                49 => {
+                    constrs.push(|x| Ok(Box::new(SwitchConstruction::deserialize(x)?)));
+                }
+                60 => {
+                    constrs.push(|x| Ok(Box::new(BaseCombatAiConstruction::deserialize(x)?)));
+                }
+                61 => {
+                    constrs.push(|x| Ok(Box::new(ModuleAssemblyConstruction::deserialize(x)?)));
+                }
+                71 => {
+                    constrs.push(|x| Ok(Box::new(RacingControlConstruction::deserialize(x)?)));
+                }
+                75 => {
+                    constrs.push(|x| Ok(Box::new(LupExhibitConstruction::deserialize(x)?)));
+                }
+                98 => {
+                    constrs.push(|x| Ok(Box::new(BuffConstruction::deserialize(x)?)));
+                }
+                100 => {
+                    constrs.push(|x| Ok(Box::new(DonationVendorConstruction::deserialize(x)?)));
+                }
+                102 => {
+                    constrs.push(|x| Ok(Box::new(AchievementVendorConstruction::deserialize(x)?)));
+                }
+                106 => {
+                    constrs
+                        .push(|x| Ok(Box::new(PlayerForcedMovementConstruction::deserialize(x)?)));
+                }
+                107 => {
+                    constrs.push(|x| Ok(Box::new(BbbConstruction::deserialize(x)?)));
+                }
+                108 => {
+                    constrs.push(|x| Ok(Box::new(PossessableConstruction::deserialize(x)?)));
+                }
+                109 => {
+                    constrs.push(|x| Ok(Box::new(LevelProgressionConstruction::deserialize(x)?)));
+                }
+                110 => {
+                    constrs.push(|x| Ok(Box::new(PossessionControlConstruction::deserialize(x)?)));
+                }
+                2 | 12 | 24 | 27 | 31 | 35 | 36 | 43 | 45 | 55 | 56 | 57 | 64 | 65 | 67 | 68
+                | 73 | 74 | 78 | 95 | 104 | 113 | 114 => {}
+                x => panic!("{}", x),
+            }
+        }
+        constrs
+    }
 }
 
 impl std::io::Read for ZipContext<'_> {
-	fn read(&mut self, buf: &mut [u8]) -> Res<usize> {
-		self.zip.read(buf)
-	}
+    fn read(&mut self, buf: &mut [u8]) -> Res<usize> {
+        self.zip.read(buf)
+    }
 }
 
 // hacky hardcoded components to be able to read player replicas without DB lookup
 impl ReplicaContext for ZipContext<'_> {
-	fn get_comp_constructions<R: std::io::Read>(&mut self, network_id: u16, lot: Lot, config: &Option<LuNameValue>) -> Vec<fn(&mut BEBitReader<R>) -> Res<Box<dyn ComponentConstruction>>> {
-		let mut comps = self.cdclient.get_comps(lot).clone();
+    fn get_comp_constructions<R: std::io::Read>(
+        &mut self,
+        network_id: u16,
+        lot: Lot,
+        config: &Option<LuNameValue>,
+    ) -> Vec<fn(&mut BEBitReader<R>) -> Res<Box<dyn ComponentConstruction>>> {
+        let mut comps = self.cdclient.get_comps(lot).clone();
 
-		Self::apply_whitelist(&mut comps, config);
-		Self::apply_config_overrides(&mut comps, config);
+        Self::apply_whitelist(&mut comps, config);
+        Self::apply_config_overrides(&mut comps, config);
 
-		comps.sort_by_key(|x| COMP_ORDER.iter().position(|y| y == x).unwrap_or(usize::MAX));
-		comps.dedup();
+        comps.sort_by_key(|x| COMP_ORDER.iter().position(|y| y == x).unwrap_or(usize::MAX));
+        comps.dedup();
 
-		let mut final_comps = vec![];
-		Self::apply_component_overrides(&comps, &mut final_comps);
-		let constrs = Self::map_constrs(&final_comps);
-		self.comps.insert(network_id, final_comps);
-		constrs
-	}
+        let mut final_comps = vec![];
+        Self::apply_component_overrides(&comps, &mut final_comps);
+        let constrs = Self::map_constrs(&final_comps);
+        self.comps.insert(network_id, final_comps);
+        constrs
+    }
 
-	fn get_comp_serializations<R: std::io::Read>(&mut self, network_id: u16) -> Vec<fn(&mut BEBitReader<R>) -> Res<Box<dyn ComponentSerialization>>> {
-		use endio::Deserialize;
+    fn get_comp_serializations<R: std::io::Read>(
+        &mut self,
+        network_id: u16,
+    ) -> Vec<fn(&mut BEBitReader<R>) -> Res<Box<dyn ComponentSerialization>>> {
+        use endio::Deserialize;
 
-		if let Some(comps) = self.comps.get(&network_id) {
-			let mut sers: Vec<fn(&mut BEBitReader<R>) -> Res<Box<dyn ComponentSerialization>>> = vec![];
-			for comp in comps {
-				match comp {
-					1   => { sers.push(|x| Ok(Box::new(ControllablePhysicsSerialization::deserialize(x)?))); }
-					3   => { sers.push(|x| Ok(Box::new(SimplePhysicsSerialization::deserialize(x)?))); }
-					4   => { sers.push(|x| Ok(Box::new(CharacterSerialization::deserialize(x)?))); }
-					6   => { sers.push(|x| Ok(Box::new(BouncerSerialization::deserialize(x)?))); }
-					7   => { sers.push(|x| Ok(Box::new(DestroyableSerialization::deserialize(x)?))); }
-					11  => { sers.push(|x| Ok(Box::new(ItemSerialization::deserialize(x)?))); }
-					16  => { sers.push(|x| Ok(Box::new(VendorSerialization::deserialize(x)?))); }
-					17  => { sers.push(|x| Ok(Box::new(InventorySerialization::deserialize(x)?))); }
-					19  => { sers.push(|x| Ok(Box::new(ShootingGallerySerialization::deserialize(x)?))); }
-					20  => { sers.push(|x| Ok(Box::new(RigidBodyPhantomPhysicsSerialization::deserialize(x)?))); }
-					23  => { sers.push(|x| Ok(Box::new(CollectibleSerialization::deserialize(x)?))); }
-					25  => { sers.push(|x| Ok(Box::new(MovingPlatformSerialization::deserialize(x)?))); }
-					26  => { sers.push(|x| Ok(Box::new(PetSerialization::deserialize(x)?))); }
-					30  => { sers.push(|x| Ok(Box::new(VehiclePhysicsSerialization::deserialize(x)?))); }
-					39  => { sers.push(|x| Ok(Box::new(ScriptedActivitySerialization::deserialize(x)?))); }
-					40  => { sers.push(|x| Ok(Box::new(PhantomPhysicsSerialization::deserialize(x)?))); }
-					42  => { sers.push(|x| Ok(Box::new(MutableModelBehaviorSerialization::deserialize(x)?))); }
-					48  => { sers.push(|x| Ok(Box::new(QuickbuildSerialization::deserialize(x)?))); }
-					49  => { sers.push(|x| Ok(Box::new(SwitchSerialization::deserialize(x)?))); }
-					60  => { sers.push(|x| Ok(Box::new(BaseCombatAiSerialization::deserialize(x)?))); }
-					71  => { sers.push(|x| Ok(Box::new(RacingControlSerialization::deserialize(x)?))); }
-					75  => { sers.push(|x| Ok(Box::new(LupExhibitSerialization::deserialize(x)?))); }
-					100 => { sers.push(|x| Ok(Box::new(DonationVendorSerialization::deserialize(x)?))); }
-					102 => { sers.push(|x| Ok(Box::new(AchievementVendorSerialization::deserialize(x)?))); }
-					106 => { sers.push(|x| Ok(Box::new(PlayerForcedMovementSerialization::deserialize(x)?))); }
-					107 => { sers.push(|x| Ok(Box::new(BbbSerialization::deserialize(x)?))); }
-					108 => { sers.push(|x| Ok(Box::new(PossessableSerialization::deserialize(x)?))); }
-					109 => { sers.push(|x| Ok(Box::new(LevelProgressionSerialization::deserialize(x)?))); }
-					110 => { sers.push(|x| Ok(Box::new(PossessionControlSerialization::deserialize(x)?))); }
-					2 | 5 | 9 | 12 | 24 | 27 | 31 | 35 | 36 | 43 | 44 | 45 | 55 | 56 | 57 | 61 | 64 | 65 | 67 | 68 | 73 | 74 | 78 | 95 | 98 | 104 | 113 | 114 => {},
-					x => panic!("{}", x),
-				}
-			}
-			self.assert_fully_read = true;
-			return sers;
-		}
-		self.assert_fully_read = false;
-		vec![]
-	}
+        if let Some(comps) = self.comps.get(&network_id) {
+            let mut sers: Vec<fn(&mut BEBitReader<R>) -> Res<Box<dyn ComponentSerialization>>> =
+                vec![];
+            for comp in comps {
+                match comp {
+                    1 => {
+                        sers.push(|x| {
+                            Ok(Box::new(ControllablePhysicsSerialization::deserialize(x)?))
+                        });
+                    }
+                    3 => {
+                        sers.push(|x| Ok(Box::new(SimplePhysicsSerialization::deserialize(x)?)));
+                    }
+                    4 => {
+                        sers.push(|x| Ok(Box::new(CharacterSerialization::deserialize(x)?)));
+                    }
+                    6 => {
+                        sers.push(|x| Ok(Box::new(BouncerSerialization::deserialize(x)?)));
+                    }
+                    7 => {
+                        sers.push(|x| Ok(Box::new(DestroyableSerialization::deserialize(x)?)));
+                    }
+                    11 => {
+                        sers.push(|x| Ok(Box::new(ItemSerialization::deserialize(x)?)));
+                    }
+                    16 => {
+                        sers.push(|x| Ok(Box::new(VendorSerialization::deserialize(x)?)));
+                    }
+                    17 => {
+                        sers.push(|x| Ok(Box::new(InventorySerialization::deserialize(x)?)));
+                    }
+                    19 => {
+                        sers.push(|x| Ok(Box::new(ShootingGallerySerialization::deserialize(x)?)));
+                    }
+                    20 => {
+                        sers.push(|x| {
+                            Ok(Box::new(RigidBodyPhantomPhysicsSerialization::deserialize(
+                                x,
+                            )?))
+                        });
+                    }
+                    23 => {
+                        sers.push(|x| Ok(Box::new(CollectibleSerialization::deserialize(x)?)));
+                    }
+                    25 => {
+                        sers.push(|x| Ok(Box::new(MovingPlatformSerialization::deserialize(x)?)));
+                    }
+                    26 => {
+                        sers.push(|x| Ok(Box::new(PetSerialization::deserialize(x)?)));
+                    }
+                    30 => {
+                        sers.push(|x| Ok(Box::new(VehiclePhysicsSerialization::deserialize(x)?)));
+                    }
+                    39 => {
+                        sers.push(|x| Ok(Box::new(ScriptedActivitySerialization::deserialize(x)?)));
+                    }
+                    40 => {
+                        sers.push(|x| Ok(Box::new(PhantomPhysicsSerialization::deserialize(x)?)));
+                    }
+                    42 => {
+                        sers.push(|x| {
+                            Ok(Box::new(MutableModelBehaviorSerialization::deserialize(x)?))
+                        });
+                    }
+                    48 => {
+                        sers.push(|x| Ok(Box::new(QuickbuildSerialization::deserialize(x)?)));
+                    }
+                    49 => {
+                        sers.push(|x| Ok(Box::new(SwitchSerialization::deserialize(x)?)));
+                    }
+                    60 => {
+                        sers.push(|x| Ok(Box::new(BaseCombatAiSerialization::deserialize(x)?)));
+                    }
+                    71 => {
+                        sers.push(|x| Ok(Box::new(RacingControlSerialization::deserialize(x)?)));
+                    }
+                    75 => {
+                        sers.push(|x| Ok(Box::new(LupExhibitSerialization::deserialize(x)?)));
+                    }
+                    100 => {
+                        sers.push(|x| Ok(Box::new(DonationVendorSerialization::deserialize(x)?)));
+                    }
+                    102 => {
+                        sers.push(|x| {
+                            Ok(Box::new(AchievementVendorSerialization::deserialize(x)?))
+                        });
+                    }
+                    106 => {
+                        sers.push(|x| {
+                            Ok(Box::new(PlayerForcedMovementSerialization::deserialize(x)?))
+                        });
+                    }
+                    107 => {
+                        sers.push(|x| Ok(Box::new(BbbSerialization::deserialize(x)?)));
+                    }
+                    108 => {
+                        sers.push(|x| Ok(Box::new(PossessableSerialization::deserialize(x)?)));
+                    }
+                    109 => {
+                        sers.push(|x| Ok(Box::new(LevelProgressionSerialization::deserialize(x)?)));
+                    }
+                    110 => {
+                        sers.push(|x| {
+                            Ok(Box::new(PossessionControlSerialization::deserialize(x)?))
+                        });
+                    }
+                    2 | 5 | 9 | 12 | 24 | 27 | 31 | 35 | 36 | 43 | 44 | 45 | 55 | 56 | 57 | 61
+                    | 64 | 65 | 67 | 68 | 73 | 74 | 78 | 95 | 98 | 104 | 113 | 114 => {}
+                    x => panic!("{}", x),
+                }
+            }
+            self.assert_fully_read = true;
+            return sers;
+        }
+        self.assert_fully_read = false;
+        vec![]
+    }
 }

--- a/src/auth/client/mod.rs
+++ b/src/auth/client/mod.rs
@@ -1,12 +1,12 @@
 //! Client-received auth messages.
 use std::io::Result as Res;
 
-use endio::{LEWrite, Serialize};
 use endio::LittleEndian as LE;
+use endio::{LEWrite, Serialize};
 use lu_packets_derive::MessageFromVariants;
 
 use crate::common::{LuString33, LuVarWString, LuWString33, ServiceId};
-use crate::general::client::{DisconnectNotify, Handshake, GeneralMessage};
+use crate::general::client::{DisconnectNotify, GeneralMessage, Handshake};
 
 /// All messages that can be received by a client from an auth server.
 pub type Message = crate::raknet::client::Message<LuMessage>;
@@ -15,104 +15,109 @@ pub type Message = crate::raknet::client::Message<LuMessage>;
 #[derive(Debug, MessageFromVariants, PartialEq, Serialize)]
 #[repr(u16)]
 pub enum LuMessage {
-	General(GeneralMessage) = ServiceId::General as u16,
-	Client(ClientMessage) = ServiceId::Client as u16,
+    General(GeneralMessage) = ServiceId::General as u16,
+    Client(ClientMessage) = ServiceId::Client as u16,
 }
 
 impl From<LuMessage> for Message {
-	fn from(msg: LuMessage) -> Self {
-		Message::UserMessage(msg)
-	}
+    fn from(msg: LuMessage) -> Self {
+        Message::UserMessage(msg)
+    }
 }
 
 impl From<Handshake> for Message {
-	fn from(msg: Handshake) -> Self {
-		GeneralMessage::Handshake(msg).into()
-	}
+    fn from(msg: Handshake) -> Self {
+        GeneralMessage::Handshake(msg).into()
+    }
 }
 
 impl From<DisconnectNotify> for Message {
-	fn from(msg: DisconnectNotify) -> Self {
-		GeneralMessage::DisconnectNotify(msg).into()
-	}
+    fn from(msg: DisconnectNotify) -> Self {
+        GeneralMessage::DisconnectNotify(msg).into()
+    }
 }
 
 /// All client-received auth messages.
 #[derive(Debug, MessageFromVariants, PartialEq, Serialize)]
-#[post_disc_padding=1]
+#[post_disc_padding = 1]
 #[repr(u32)]
 pub enum ClientMessage {
-	LoginResponse(LoginResponse),
+    LoginResponse(LoginResponse),
 }
 
 /**
-	Responds to a login request.
+    Responds to a login request.
 
-	Sends session key and redirect address in case of success.
+    Sends session key and redirect address in case of success.
 
-	### Trigger
-	Receipt of [`LoginRequest`](super::server::LoginRequest).
+    ### Trigger
+    Receipt of [`LoginRequest`](super::server::LoginRequest).
 
-	### Handling
-	If the variant is not [`Ok`](LoginResponse::Ok), report the error to the user.
+    ### Handling
+    If the variant is not [`Ok`](LoginResponse::Ok), report the error to the user.
 
-	If the variant is `Ok`, store the [`session_key`](LoginResponse::Ok::session_key) for later use. Close the connection and open a connection to [`redirect_address`](LoginResponse::Ok::redirect_address).
+    If the variant is `Ok`, store the [`session_key`](LoginResponse::Ok::session_key) for later use. Close the connection and open a connection to [`redirect_address`](LoginResponse::Ok::redirect_address).
 
-	### Response
-	None, close the connection.
+    ### Response
+    None, close the connection.
 
-	### Notes
-	Expect the connection to be closed soon after this message is received, if you're not closing it yourself already.
+    ### Notes
+    Expect the connection to be closed soon after this message is received, if you're not closing it yourself already.
 */
 #[derive(Debug, PartialEq)]
 #[non_exhaustive]
 #[repr(u8)]
 pub enum LoginResponse {
-	/// The login was successful.
-	Ok {
-		/// The session key to be used for authenticating with world servers (to be passed in [`ClientValidation::session_key`](crate::world::server::ClientValidation::session_key)).
-		session_key: LuWString33,
-		/// The address of a world server available for further service.
-		redirect_address: (LuString33, u16),
-	} = 1,
-	/// The login failed in an unusual way. More information can be found in the attached message.
-	CustomMessage(LuVarWString<u16>) = 5,
-	/// Username or password was incorrect.
-	InvalidUsernamePassword = 6,
+    /// The login was successful.
+    Ok {
+        /// The session key to be used for authenticating with world servers (to be passed in [`ClientValidation::session_key`](crate::world::server::ClientValidation::session_key)).
+        session_key: LuWString33,
+        /// The address of a world server available for further service.
+        redirect_address: (LuString33, u16),
+    } = 1,
+    /// The login failed in an unusual way. More information can be found in the attached message.
+    CustomMessage(LuVarWString<u16>) = 5,
+    /// Username or password was incorrect.
+    InvalidUsernamePassword = 6,
 }
 
 impl<'a, W: LEWrite> Serialize<LE, W> for &'a LoginResponse
-	where       u8: Serialize<LE, W>,
-	           u16: Serialize<LE, W>,
-	           u32: Serialize<LE, W>,
-	      &'a [u8]: Serialize<LE, W>,
-	   &'a LuString33: Serialize<LE, W>,
-	  &'a LuWString33: Serialize<LE, W>,
-	  &'a LuVarWString<u16>: Serialize<LE, W> {
-	fn serialize(self, writer: &mut W) -> Res<()>	{
-		let disc = unsafe { *(self as *const LoginResponse as *const u8) };
-		writer.write(disc)?;
-		match self {
-			LoginResponse::Ok { session_key, redirect_address } => {
-				writer.write(&[0; 264][..])?;
-				writer.write(1u16)?;
-				writer.write(10u16)?;
-				writer.write(64u16)?;
-				writer.write(session_key)?;
-				writer.write(&redirect_address.0)?;
-				writer.write(&[0; 33][..])?;
-				writer.write(redirect_address.1)?;
-				writer.write(&[0; 91][..])?;
-			}
-			LoginResponse::CustomMessage(msg) => {
-				writer.write(&[0; 493][..])?;
-				writer.write(msg)?;
-			}
-			LoginResponse::InvalidUsernamePassword => {
-				writer.write(&[0; 495][..])?;
-			}
-		}
-		writer.write(4u32)?;
-		Ok(())
-	}
+where
+    u8: Serialize<LE, W>,
+    u16: Serialize<LE, W>,
+    u32: Serialize<LE, W>,
+    &'a [u8]: Serialize<LE, W>,
+    &'a LuString33: Serialize<LE, W>,
+    &'a LuWString33: Serialize<LE, W>,
+    &'a LuVarWString<u16>: Serialize<LE, W>,
+{
+    fn serialize(self, writer: &mut W) -> Res<()> {
+        let disc = unsafe { *(self as *const LoginResponse as *const u8) };
+        writer.write(disc)?;
+        match self {
+            LoginResponse::Ok {
+                session_key,
+                redirect_address,
+            } => {
+                writer.write(&[0; 264][..])?;
+                writer.write(1u16)?;
+                writer.write(10u16)?;
+                writer.write(64u16)?;
+                writer.write(session_key)?;
+                writer.write(&redirect_address.0)?;
+                writer.write(&[0; 33][..])?;
+                writer.write(redirect_address.1)?;
+                writer.write(&[0; 91][..])?;
+            }
+            LoginResponse::CustomMessage(msg) => {
+                writer.write(&[0; 493][..])?;
+                writer.write(msg)?;
+            }
+            LoginResponse::InvalidUsernamePassword => {
+                writer.write(&[0; 495][..])?;
+            }
+        }
+        writer.write(4u32)?;
+        Ok(())
+    }
 }

--- a/src/auth/server/mod.rs
+++ b/src/auth/server/mod.rs
@@ -2,7 +2,7 @@
 use endio::{Deserialize, Serialize};
 use lu_packets_derive::VariantTests;
 
-use crate::common::{LuWString33, LuWString41, LuWString128, LuWString256, ServiceId};
+use crate::common::{LuWString128, LuWString256, LuWString33, LuWString41, ServiceId};
 pub use crate::general::server::GeneralMessage;
 
 /// All messages that can be received by an auth server.
@@ -13,95 +13,95 @@ pub type Message = crate::raknet::server::Message<LuMessage>;
 #[non_exhaustive]
 #[repr(u16)]
 pub enum LuMessage {
-	General(GeneralMessage) = ServiceId::General as u16,
-	Auth(AuthMessage) = ServiceId::Auth as u16,
+    General(GeneralMessage) = ServiceId::General as u16,
+    Auth(AuthMessage) = ServiceId::Auth as u16,
 }
 
 /// All server-received auth messages.
 #[derive(Debug, Deserialize, PartialEq, Serialize, VariantTests)]
-#[post_disc_padding=1]
+#[post_disc_padding = 1]
 #[repr(u32)]
 pub enum AuthMessage {
-	LoginRequest(LoginRequest)
+    LoginRequest(LoginRequest),
 }
 
 /**
-	Provides username and password to authenticate the client.
+    Provides username and password to authenticate the client.
 
-	Also provides system stats for analytics.
+    Also provides system stats for analytics.
 
-	### Trigger
-	Receipt of [`Handshake`](crate::general::client::Handshake) with a [`service_id`](crate::general::client::Handshake`::service_id) of [`ServiceId::Auth`].
+    ### Trigger
+    Receipt of [`Handshake`](crate::general::client::Handshake) with a [`service_id`](crate::general::client::Handshake`::service_id) of [`ServiceId::Auth`].
 
-	### Handling
-	Look up the username and a hashed form of the password in the database. If there is a match, generate a session key to be used as an auth token when the client connects to world servers, and save it to DB. Generate session keys in a way that makes it impossible for an attacker to guess a session key with non-neglible probability. Specifically, this means that using an incrementing number or a non-cryptographically-secure pseudo-random number generator for session keys is ***not*** secure.
+    ### Handling
+    Look up the username and a hashed form of the password in the database. If there is a match, generate a session key to be used as an auth token when the client connects to world servers, and save it to DB. Generate session keys in a way that makes it impossible for an attacker to guess a session key with non-neglible probability. Specifically, this means that using an incrementing number or a non-cryptographically-secure pseudo-random number generator for session keys is ***not*** secure.
 
-	In addition, determine the address of a char server to redirect the client to.
+    In addition, determine the address of a char server to redirect the client to.
 
-	### Response
-	Respond with [`LoginResponse`](super::client::LoginResponse), using an appropriate variant to indicate the lookup status, passing the session key and redirect address if successful.
+    ### Response
+    Respond with [`LoginResponse`](super::client::LoginResponse), using an appropriate variant to indicate the lookup status, passing the session key and redirect address if successful.
 
-	### Notes
-	The password is provided in plain text. **Don't** save this password to the database unprocessed, as this constitutes a **security hazard**. Hash and salt it using a strong cryptographic hash function before saving it.
+    ### Notes
+    The password is provided in plain text. **Don't** save this password to the database unprocessed, as this constitutes a **security hazard**. Hash and salt it using a strong cryptographic hash function before saving it.
 */
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct LoginRequest {
-	/// The client's user name.
-	pub username: LuWString33,
-	/// The client's password.
-	pub password: LuWString41,
-	/// The client's locale.
-	pub locale_id: u16,
-	/// The client's operating system.
-	pub client_os: ClientOs,
-	/// Stats about the computer the client is running on.
-	pub computer_stats: ComputerStats,
+    /// The client's user name.
+    pub username: LuWString33,
+    /// The client's password.
+    pub password: LuWString41,
+    /// The client's locale.
+    pub locale_id: u16,
+    /// The client's operating system.
+    pub client_os: ClientOs,
+    /// Stats about the computer the client is running on.
+    pub computer_stats: ComputerStats,
 }
 
 /// The client's operating system.
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[repr(u8)]
 pub enum ClientOs {
-	Unknown,
-	Windows,
-	MacOs,
+    Unknown,
+    Windows,
+    MacOs,
 }
 
 /// Stats about the computer the client is running on.
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct ComputerStats {
-	pub memory_stats: LuWString256,
-	pub video_card_info: LuWString128,
-	/// Info about the processor the client is running on. Collected from a [`GetSystemInfo`](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsysteminfo) call.
-	pub processor_info: ProcessorInfo,
-	/// Info about the operating system the client is running on. Collected from a [`GetVersionEx`](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getversionexa) call.
-	pub os_info: OsInfo,
+    pub memory_stats: LuWString256,
+    pub video_card_info: LuWString128,
+    /// Info about the processor the client is running on. Collected from a [`GetSystemInfo`](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getsysteminfo) call.
+    pub processor_info: ProcessorInfo,
+    /// Info about the operating system the client is running on. Collected from a [`GetVersionEx`](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/nf-sysinfoapi-getversionexa) call.
+    pub os_info: OsInfo,
 }
 
 /// Info about the processor the client is running on.
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct ProcessorInfo {
-	/// Number of processors. [`SYSTEM_INFO::dwNumberOfProcessors`](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info)
-	pub number_of_processors: u32,
-	/// Processor type. [`SYSTEM_INFO::dwProcessorType`](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info)
-	pub processor_type: u32,
-	/// Processor level. [`SYSTEM_INFO::wProcessorLevel`](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info)
-	pub processor_level: u16,
-	/// Processor revision. [`SYSTEM_INFO::wProcessorRevision`](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info)
-	pub processor_revision: u16,
+    /// Number of processors. [`SYSTEM_INFO::dwNumberOfProcessors`](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info)
+    pub number_of_processors: u32,
+    /// Processor type. [`SYSTEM_INFO::dwProcessorType`](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info)
+    pub processor_type: u32,
+    /// Processor level. [`SYSTEM_INFO::wProcessorLevel`](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info)
+    pub processor_level: u16,
+    /// Processor revision. [`SYSTEM_INFO::wProcessorRevision`](https://docs.microsoft.com/en-us/windows/win32/api/sysinfoapi/ns-sysinfoapi-system_info)
+    pub processor_revision: u16,
 }
 
 /// Info about the operating system the client is running on.
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct OsInfo {
-	/// Size of [`OSVERSIONINFO`](https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoa). Pretty useless.
-	pub os_version_info_size: u32,
-	/// OS major version. [`OSVERSIONINFO::dwMajorVersion`](https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoa).
-	pub major_version: u32,
-	/// OS minor version. [`OSVERSIONINFO::dwMinorVersion`](https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoa).
-	pub minor_version: u32,
-	/// OS build number. [`OSVERSIONINFO::dwBuildNumber`](https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoa).
-	pub build_number: u32,
-	/// OS platform ID. [`OSVERSIONINFO::dwPlatformId`](https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoa).
-	pub platform_id: u32,
+    /// Size of [`OSVERSIONINFO`](https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoa). Pretty useless.
+    pub os_version_info_size: u32,
+    /// OS major version. [`OSVERSIONINFO::dwMajorVersion`](https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoa).
+    pub major_version: u32,
+    /// OS minor version. [`OSVERSIONINFO::dwMinorVersion`](https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoa).
+    pub minor_version: u32,
+    /// OS build number. [`OSVERSIONINFO::dwBuildNumber`](https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoa).
+    pub build_number: u32,
+    /// OS platform ID. [`OSVERSIONINFO::dwPlatformId`](https://docs.microsoft.com/en-us/windows/win32/api/winnt/ns-winnt-osversioninfoa).
+    pub platform_id: u32,
 }

--- a/src/chat/client/mod.rs
+++ b/src/chat/client/mod.rs
@@ -1,30 +1,30 @@
 use endio::{Deserialize, Serialize};
 use lu_packets_derive::{MessageFromVariants, VariantTests};
 
+pub use super::{GeneralChatMessage, PrivateChatMessage};
 use crate::common::{LuWString33, ObjId};
 use crate::world::client::Message;
-pub use super::{GeneralChatMessage, PrivateChatMessage};
 
 #[derive(Debug, Deserialize, PartialEq, Serialize, MessageFromVariants, VariantTests)]
 #[non_exhaustive]
-#[post_disc_padding=9]
+#[post_disc_padding = 9]
 #[repr(u32)]
 pub enum ChatMessage {
-	GeneralChatMessage(GeneralChatMessage) = 1,
-	PrivateChatMessage(PrivateChatMessage) = 2,
-	AchievementNotify(AchievementNotify) = 59,
+    GeneralChatMessage(GeneralChatMessage) = 1,
+    PrivateChatMessage(PrivateChatMessage) = 2,
+    AchievementNotify(AchievementNotify) = 59,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct AchievementNotify {
-	#[padding=5]
-	pub sender_name: LuWString33,
-	pub sender: ObjId,
-	pub source_id: u16,
-	pub sender_gm_level: u8,
-	pub target_group: u32, // todo: type?
-	pub mission_message_key: u32, // todo: type?
-	pub requesting_player: ObjId,
-	pub recipient_name: LuWString33,
-	pub recipient_gm_level: u8,
+    #[padding = 5]
+    pub sender_name: LuWString33,
+    pub sender: ObjId,
+    pub source_id: u16,
+    pub sender_gm_level: u8,
+    pub target_group: u32,        // todo: type?
+    pub mission_message_key: u32, // todo: type?
+    pub requesting_player: ObjId,
+    pub recipient_name: LuWString33,
+    pub recipient_gm_level: u8,
 }

--- a/src/chat/mod.rs
+++ b/src/chat/mod.rs
@@ -2,164 +2,189 @@
 pub mod client;
 pub mod server;
 
-use std::io::{Read, Write};
 use std::io::Result as Res;
+use std::io::{Read, Write};
 
-use endio::{Deserialize, LERead, LEWrite, Serialize};
 use endio::LittleEndian as LE;
+use endio::{Deserialize, LERead, LEWrite, Serialize};
 
 use crate::common::{LuVarWString, LuWString33, ObjId};
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 #[repr(u8)]
 pub enum ChatChannel {
-	SystemNotify,
-	SystemWarning,
-	SystemError,
-	Broadcast,
-	Local,
-	LocalNoanim,
-	Emote,
-	Private,
-	Team,
-	TeamLocal,
-	Guild,
-	GuildNotify,
-	Property,
-	Admin,
-	CombatDamage,
-	CombatHealing,
-	CombatLoot,
-	CombatExp,
-	CombatDeath,
-	General,
-	Trade,
-	Lfg,
-	User,
+    SystemNotify,
+    SystemWarning,
+    SystemError,
+    Broadcast,
+    Local,
+    LocalNoanim,
+    Emote,
+    Private,
+    Team,
+    TeamLocal,
+    Guild,
+    GuildNotify,
+    Property,
+    Admin,
+    CombatDamage,
+    CombatHealing,
+    CombatLoot,
+    CombatExp,
+    CombatDeath,
+    General,
+    Trade,
+    Lfg,
+    User,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct GeneralChatMessage {
-	pub chat_channel: ChatChannel,
-	pub sender_name: LuWString33,
-	pub sender: ObjId,
-	pub source_id: u16,
-	pub sender_gm_level: u8,
-	pub message: LuVarWString<u32>,
+    pub chat_channel: ChatChannel,
+    pub sender_name: LuWString33,
+    pub sender: ObjId,
+    pub source_id: u16,
+    pub sender_gm_level: u8,
+    pub message: LuVarWString<u32>,
 }
 
-impl<R: Read+LERead> Deserialize<LE, R> for GeneralChatMessage
-	where   u8: Deserialize<LE, R>,
-	       u16: Deserialize<LE, R>,
-	       u32: Deserialize<LE, R>,
-	  LuWString33: Deserialize<LE, R>,
-	     ObjId: Deserialize<LE, R> {
-	fn deserialize(reader: &mut R) -> Res<Self> {
-		let chat_channel     = LERead::read(reader)?;
-		let mut str_len: u32 = LERead::read(reader)?;
-		if chat_channel == ChatChannel::Team {
-			str_len -= 1;
-		}
-		let sender_name      = LERead::read(reader)?;
-		let sender           = LERead::read(reader)?;
-		let source_id        = LERead::read(reader)?;
-		let sender_gm_level  = LERead::read(reader)?;
-		let message = LuVarWString::deser_content(reader, str_len)?;
-		let _: u16           = LERead::read(reader)?;
-		Ok(Self { chat_channel, sender_name, sender, source_id, sender_gm_level, message })
-	}
+impl<R: Read + LERead> Deserialize<LE, R> for GeneralChatMessage
+where
+    u8: Deserialize<LE, R>,
+    u16: Deserialize<LE, R>,
+    u32: Deserialize<LE, R>,
+    LuWString33: Deserialize<LE, R>,
+    ObjId: Deserialize<LE, R>,
+{
+    fn deserialize(reader: &mut R) -> Res<Self> {
+        let chat_channel = LERead::read(reader)?;
+        let mut str_len: u32 = LERead::read(reader)?;
+        if chat_channel == ChatChannel::Team {
+            str_len -= 1;
+        }
+        let sender_name = LERead::read(reader)?;
+        let sender = LERead::read(reader)?;
+        let source_id = LERead::read(reader)?;
+        let sender_gm_level = LERead::read(reader)?;
+        let message = LuVarWString::deser_content(reader, str_len)?;
+        let _: u16 = LERead::read(reader)?;
+        Ok(Self {
+            chat_channel,
+            sender_name,
+            sender,
+            source_id,
+            sender_gm_level,
+            message,
+        })
+    }
 }
 
-impl<'a, W: Write+LEWrite> Serialize<LE, W> for &'a GeneralChatMessage
-	where       u8: Serialize<LE, W>,
-	           u16: Serialize<LE, W>,
-	           u32: Serialize<LE, W>,
-	  &'a LuWString33: Serialize<LE, W>,
-	         ObjId: Serialize<LE, W> {
-	fn serialize(self, writer: &mut W) -> Res<()> {
-		LEWrite::write(writer, &self.chat_channel)?;
-		let mut str_len = self.message.len();
-		if self.chat_channel == ChatChannel::Team {
-			str_len += 1;
-		}
-		LEWrite::write(writer, str_len as u32)?;
-		LEWrite::write(writer, &self.sender_name)?;
-		LEWrite::write(writer, self.sender)?;
-		LEWrite::write(writer, self.source_id)?;
-		LEWrite::write(writer, self.sender_gm_level)?;
-		self.message.ser_content(writer)?;
-		LEWrite::write(writer, 0u16)
-	}
+impl<'a, W: Write + LEWrite> Serialize<LE, W> for &'a GeneralChatMessage
+where
+    u8: Serialize<LE, W>,
+    u16: Serialize<LE, W>,
+    u32: Serialize<LE, W>,
+    &'a LuWString33: Serialize<LE, W>,
+    ObjId: Serialize<LE, W>,
+{
+    fn serialize(self, writer: &mut W) -> Res<()> {
+        LEWrite::write(writer, &self.chat_channel)?;
+        let mut str_len = self.message.len();
+        if self.chat_channel == ChatChannel::Team {
+            str_len += 1;
+        }
+        LEWrite::write(writer, str_len as u32)?;
+        LEWrite::write(writer, &self.sender_name)?;
+        LEWrite::write(writer, self.sender)?;
+        LEWrite::write(writer, self.source_id)?;
+        LEWrite::write(writer, self.sender_gm_level)?;
+        self.message.ser_content(writer)?;
+        LEWrite::write(writer, 0u16)
+    }
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[repr(u8)]
 pub enum PrivateChatMessageResponseCode {
-	Sent,
-	NotOnline,
-	GeneralError,
-	ReceivedNewWhisper,
-	NotFriends,
-	SenderFreeTrial,
-	ReceiverFreeTrial,
+    Sent,
+    NotOnline,
+    GeneralError,
+    ReceivedNewWhisper,
+    NotFriends,
+    SenderFreeTrial,
+    ReceiverFreeTrial,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct PrivateChatMessage {
-	pub chat_channel: ChatChannel,
-	pub sender_name: LuWString33,
-	pub sender: ObjId,
-	pub source_id: u16,
-	pub sender_gm_level: u8,
-	pub recipient_name: LuWString33,
-	pub recipient_gm_level: u8,
-	pub response_code: PrivateChatMessageResponseCode,
-	pub message: LuVarWString<u32>,
+    pub chat_channel: ChatChannel,
+    pub sender_name: LuWString33,
+    pub sender: ObjId,
+    pub source_id: u16,
+    pub sender_gm_level: u8,
+    pub recipient_name: LuWString33,
+    pub recipient_gm_level: u8,
+    pub response_code: PrivateChatMessageResponseCode,
+    pub message: LuVarWString<u32>,
 }
 
-impl<R: Read+LERead> Deserialize<LE, R> for PrivateChatMessage
-	where   u8: Deserialize<LE, R>,
-	       u16: Deserialize<LE, R>,
-	       u32: Deserialize<LE, R>,
-	  LuWString33: Deserialize<LE, R>,
-	     ObjId: Deserialize<LE, R>,
-	  PrivateChatMessageResponseCode: Deserialize<LE, R> {
-	fn deserialize(reader: &mut R) -> Res<Self> {
-		let chat_channel       = LERead::read(reader)?;
-		let mut str_len: u32       = LERead::read(reader)?;
-		str_len -= 1;
-		let sender_name        = LERead::read(reader)?;
-		let sender             = LERead::read(reader)?;
-		let source_id          = LERead::read(reader)?;
-		let sender_gm_level    = LERead::read(reader)?;
-		let recipient_name     = LERead::read(reader)?;
-		let recipient_gm_level = LERead::read(reader)?;
-		let response_code      = LERead::read(reader)?;
-		let message = LuVarWString::deser_content(reader, str_len)?;
-		let _: u16             = LERead::read(reader)?;
-		Ok(Self { chat_channel, sender_name, sender, source_id, sender_gm_level, recipient_name, recipient_gm_level, response_code, message })
-	}
+impl<R: Read + LERead> Deserialize<LE, R> for PrivateChatMessage
+where
+    u8: Deserialize<LE, R>,
+    u16: Deserialize<LE, R>,
+    u32: Deserialize<LE, R>,
+    LuWString33: Deserialize<LE, R>,
+    ObjId: Deserialize<LE, R>,
+    PrivateChatMessageResponseCode: Deserialize<LE, R>,
+{
+    fn deserialize(reader: &mut R) -> Res<Self> {
+        let chat_channel = LERead::read(reader)?;
+        let mut str_len: u32 = LERead::read(reader)?;
+        str_len -= 1;
+        let sender_name = LERead::read(reader)?;
+        let sender = LERead::read(reader)?;
+        let source_id = LERead::read(reader)?;
+        let sender_gm_level = LERead::read(reader)?;
+        let recipient_name = LERead::read(reader)?;
+        let recipient_gm_level = LERead::read(reader)?;
+        let response_code = LERead::read(reader)?;
+        let message = LuVarWString::deser_content(reader, str_len)?;
+        let _: u16 = LERead::read(reader)?;
+        Ok(Self {
+            chat_channel,
+            sender_name,
+            sender,
+            source_id,
+            sender_gm_level,
+            recipient_name,
+            recipient_gm_level,
+            response_code,
+            message,
+        })
+    }
 }
-impl<'a, W: Write+LEWrite> Serialize<LE, W> for &'a PrivateChatMessage
-	where       u8: Serialize<LE, W>,
-	           u16: Serialize<LE, W>,
-	           u32: Serialize<LE, W>,
-	  &'a LuWString33: Serialize<LE, W>,
-	         ObjId: Serialize<LE, W>,
-	  &'a PrivateChatMessageResponseCode: Serialize<LE, W> {
-	fn serialize(self, writer: &mut W) -> Res<()> {
-		LEWrite::write(writer, &self.chat_channel)?;
-		let mut str_len = self.message.len();
-		str_len += 1;
-		LEWrite::write(writer, str_len as u32)?;
-		LEWrite::write(writer, &self.sender_name)?;
-		LEWrite::write(writer, self.sender)?;
-		LEWrite::write(writer, self.source_id)?;
-		LEWrite::write(writer, self.sender_gm_level)?;
-		LEWrite::write(writer, &self.recipient_name)?;
-		LEWrite::write(writer, self.recipient_gm_level)?;
-		LEWrite::write(writer, &self.response_code)?;
-		self.message.ser_content(writer)?;
-		LEWrite::write(writer, 0u16)
-	}
+impl<'a, W: Write + LEWrite> Serialize<LE, W> for &'a PrivateChatMessage
+where
+    u8: Serialize<LE, W>,
+    u16: Serialize<LE, W>,
+    u32: Serialize<LE, W>,
+    &'a LuWString33: Serialize<LE, W>,
+    ObjId: Serialize<LE, W>,
+    &'a PrivateChatMessageResponseCode: Serialize<LE, W>,
+{
+    fn serialize(self, writer: &mut W) -> Res<()> {
+        LEWrite::write(writer, &self.chat_channel)?;
+        let mut str_len = self.message.len();
+        str_len += 1;
+        LEWrite::write(writer, str_len as u32)?;
+        LEWrite::write(writer, &self.sender_name)?;
+        LEWrite::write(writer, self.sender)?;
+        LEWrite::write(writer, self.source_id)?;
+        LEWrite::write(writer, self.sender_gm_level)?;
+        LEWrite::write(writer, &self.recipient_name)?;
+        LEWrite::write(writer, self.recipient_gm_level)?;
+        LEWrite::write(writer, &self.response_code)?;
+        self.message.ser_content(writer)?;
+        LEWrite::write(writer, 0u16)
+    }
 }

--- a/src/chat/server/mod.rs
+++ b/src/chat/server/mod.rs
@@ -1,86 +1,86 @@
 use endio::{Deserialize, Serialize};
 use lu_packets_derive::VariantTests;
 
-use crate::common::{LuWString33, ObjId};
-pub use super::{GeneralChatMessage, PrivateChatMessage};
 use super::ChatChannel;
+pub use super::{GeneralChatMessage, PrivateChatMessage};
+use crate::common::{LuWString33, ObjId};
 
 #[derive(Debug, Deserialize, PartialEq, Serialize, VariantTests)]
-#[post_disc_padding=9]
+#[post_disc_padding = 9]
 #[repr(u32)]
 pub enum ChatMessage {
-	GeneralChatMessage(GeneralChatMessage) = 1,
-	PrivateChatMessage(PrivateChatMessage) = 2,
-	AddFriendRequest(AddFriendRequest) = 7,
-	AddFriendResponse(AddFriendResponse) = 8,
-	GetFriendsList = 10,
-	AddIgnore(AddIgnore) = 11,
-	GetIgnoreList = 13,
-	TeamInvite(TeamInvite) = 15,
-	TeamInviteResponse(TeamInviteResponse) = 16,
-	TeamLeave(TeamLeave) = 18,
-	TeamGetStatus = 21,
-	RequestMinimumChatMode(RequestMinimumChatMode) = 50,
-	RequestMinimumChatModePrivate(RequestMinimumChatModePrivate) = 51,
+    GeneralChatMessage(GeneralChatMessage) = 1,
+    PrivateChatMessage(PrivateChatMessage) = 2,
+    AddFriendRequest(AddFriendRequest) = 7,
+    AddFriendResponse(AddFriendResponse) = 8,
+    GetFriendsList = 10,
+    AddIgnore(AddIgnore) = 11,
+    GetIgnoreList = 13,
+    TeamInvite(TeamInvite) = 15,
+    TeamInviteResponse(TeamInviteResponse) = 16,
+    TeamLeave(TeamLeave) = 18,
+    TeamGetStatus = 21,
+    RequestMinimumChatMode(RequestMinimumChatMode) = 50,
+    RequestMinimumChatModePrivate(RequestMinimumChatModePrivate) = 51,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[repr(u8)]
 pub enum AddFriendResponseCode {
-	Accepted,
-	Rejected,
-	Busy,
-	Cancelled,
+    Accepted,
+    Rejected,
+    Busy,
+    Cancelled,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct AddFriendRequest {
-	pub friend_name: LuWString33,
-	pub is_best_friend: bool,
+    pub friend_name: LuWString33,
+    pub is_best_friend: bool,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct AddFriendResponse {
-	pub response_code: AddFriendResponseCode,
-	pub friend_name: LuWString33,
+    pub response_code: AddFriendResponseCode,
+    pub friend_name: LuWString33,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct AddIgnore {
-	pub char_name: LuWString33,
+    pub char_name: LuWString33,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[repr(u8)]
 pub enum TeamInviteResponseCode {
-	Accepted,
-	Rejected,
-	GeneralError,
+    Accepted,
+    Rejected,
+    GeneralError,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct TeamInvite {
-	pub sender_name: LuWString33,
+    pub sender_name: LuWString33,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct TeamInviteResponse {
-	pub response_code: TeamInviteResponseCode,
-	pub sender: ObjId,
+    pub response_code: TeamInviteResponseCode,
+    pub sender: ObjId,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct TeamLeave {
-	pub unused: LuWString33,
+    pub unused: LuWString33,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct RequestMinimumChatMode {
-	pub chat_channel: ChatChannel,
+    pub chat_channel: ChatChannel,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct RequestMinimumChatModePrivate {
-	pub chat_channel: ChatChannel,
-	pub recipient_name: LuWString33,
+    pub chat_channel: ChatChannel,
+    pub recipient_name: LuWString33,
 }

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -2,122 +2,133 @@
 mod str;
 
 use std::convert::{TryFrom, TryInto};
-use std::fmt::{Formatter, Debug};
-use std::io::{Read, Write};
+use std::fmt::{Debug, Formatter};
 use std::io::Result as Res;
+use std::io::{Read, Write};
 use std::marker::PhantomData;
 
-use endio::{Deserialize, LE, LERead, LEWrite, Serialize};
+use endio::{Deserialize, LERead, LEWrite, Serialize, LE};
 
 pub use self::str::*;
 
 /**
-	Wraps a `Vec` with a length type so the vector can be (de-)serialized.
+    Wraps a `Vec` with a length type so the vector can be (de-)serialized.
 
-	Note: the length type is not checked and the `Vec` still uses `usize` internally. Handle with care.
+    Note: the length type is not checked and the `Vec` still uses `usize` internally. Handle with care.
 */
 #[derive(Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct LVec<L, T>(Vec<T>, PhantomData<L>);
 
 impl<L, T> LVec<L, T> {
-	pub fn new() -> Self {
-		Self(Vec::new(), PhantomData)
-	}
+    pub fn new() -> Self {
+        Self(Vec::new(), PhantomData)
+    }
 
-	pub fn with_capacity(capacity: usize) -> Self {
-		Self(Vec::with_capacity(capacity), PhantomData)
-	}
+    pub fn with_capacity(capacity: usize) -> Self {
+        Self(Vec::with_capacity(capacity), PhantomData)
+    }
 
-	pub fn inner(&self) -> &Vec<T> {
-		&self.0
-	}
+    pub fn inner(&self) -> &Vec<T> {
+        &self.0
+    }
 
-	pub(crate) fn deser_content<R: Read>(reader: &mut R, len: L) -> Res<Self> where L: TryInto<usize>, T: Deserialize<LE, R> {
-		let len = match len.try_into() {
-			Ok(x) => x,
-			_ => panic!(),
-		};
-		let mut vec = Vec::<T>::with_capacity(len);
-		for _ in 0..len {
-			vec.push(LERead::read(reader)?);
-		}
-		Ok(Self(vec, PhantomData))
-	}
+    pub(crate) fn deser_content<R: Read>(reader: &mut R, len: L) -> Res<Self>
+    where
+        L: TryInto<usize>,
+        T: Deserialize<LE, R>,
+    {
+        let len = match len.try_into() {
+            Ok(x) => x,
+            _ => panic!(),
+        };
+        let mut vec = Vec::<T>::with_capacity(len);
+        for _ in 0..len {
+            vec.push(LERead::read(reader)?);
+        }
+        Ok(Self(vec, PhantomData))
+    }
 
-	pub(crate) fn ser_len<W: LEWrite>(&self, writer: &mut W) -> Res<()> where L: TryFrom<usize> + Serialize<LE, W> {
-		let len = self.0.len();
-		let l_len = match L::try_from(len) {
-			Ok(x) => x,
-			_ => panic!(),
-		};
-		writer.write(l_len)
-	}
+    pub(crate) fn ser_len<W: LEWrite>(&self, writer: &mut W) -> Res<()>
+    where
+        L: TryFrom<usize> + Serialize<LE, W>,
+    {
+        let len = self.0.len();
+        let l_len = match L::try_from(len) {
+            Ok(x) => x,
+            _ => panic!(),
+        };
+        writer.write(l_len)
+    }
 
-	pub(crate) fn ser_content<W: Write>(&self, writer: &mut W) -> Res<()> where for<'a> &'a T: Serialize<LE, W> {
-		for e in &self.0 {
-			LEWrite::write(writer, e)?;
-		}
-		Ok(())
-	}
+    pub(crate) fn ser_content<W: Write>(&self, writer: &mut W) -> Res<()>
+    where
+        for<'a> &'a T: Serialize<LE, W>,
+    {
+        for e in &self.0 {
+            LEWrite::write(writer, e)?;
+        }
+        Ok(())
+    }
 }
 
 impl<L, T: Debug> Debug for LVec<L, T> {
-	fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-		self.0.fmt(f)
-	}
+    fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
 }
 
 impl<L, T, R: Read> Deserialize<LE, R> for LVec<L, T>
-	where L: TryInto<usize> + Deserialize<LE, R>,
-	      T: Deserialize<LE, R>	{
-
-	fn deserialize(reader: &mut R) -> Res<Self> {
-		let len: L = LERead::read(reader)?;
-		Self::deser_content(reader, len)
-	}
+where
+    L: TryInto<usize> + Deserialize<LE, R>,
+    T: Deserialize<LE, R>,
+{
+    fn deserialize(reader: &mut R) -> Res<Self> {
+        let len: L = LERead::read(reader)?;
+        Self::deser_content(reader, len)
+    }
 }
 
 impl<'a, L, T, W: Write> Serialize<LE, W> for &'a LVec<L, T>
-	where L: TryFrom<usize> + Serialize<LE, W>,
-	  for<'b> &'b T: Serialize<LE, W> {
-
-	fn serialize(self, writer: &mut W) -> Res<()> {
-		self.ser_len(writer)?;
-		self.ser_content(writer)
-	}
+where
+    L: TryFrom<usize> + Serialize<LE, W>,
+    for<'b> &'b T: Serialize<LE, W>,
+{
+    fn serialize(self, writer: &mut W) -> Res<()> {
+        self.ser_len(writer)?;
+        self.ser_content(writer)
+    }
 }
 
 impl<L, T> std::ops::Deref for LVec<L, T> {
-	type Target = Vec<T>;
+    type Target = Vec<T>;
 
-	#[inline]
-	fn deref(&self) -> &Self::Target {
-		&self.0
-	}
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl<L, T> std::ops::DerefMut for LVec<L, T> {
-	#[inline]
-	fn deref_mut(&mut self) -> &mut Self::Target {
-		&mut self.0
-	}
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
 }
 
 impl<L, T> From<Vec<T>> for LVec<L, T> {
-	fn from(vec: Vec<T>) -> Self {
-		Self(vec, PhantomData)
-	}
+    fn from(vec: Vec<T>) -> Self {
+        Self(vec, PhantomData)
+    }
 }
-
 
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
 #[repr(u16)]
 pub enum ServiceId {
-	General = 0,
-	Auth = 1,
-	Chat = 2,
-	World = 4,
-	Client = 5,
+    General = 0,
+    Auth = 1,
+    Chat = 2,
+    World = 4,
+    Client = 5,
 }
 
 pub type ObjId = u64;

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -19,6 +19,12 @@ pub use self::str::*;
 #[derive(Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct LVec<L, T>(Vec<T>, PhantomData<L>);
 
+impl<L, T> Default for LVec<L, T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<L, T> LVec<L, T> {
     pub fn new() -> Self {
         Self(Vec::new(), PhantomData)

--- a/src/common/str/fixed.rs
+++ b/src/common/str/fixed.rs
@@ -47,7 +47,7 @@ macro_rules! abstract_lu_str {
         impl<R: Read> Deserialize<LE, R> for $name {
             fn deserialize(reader: &mut R) -> Res<Self> {
                 let mut bytes = [0u8; $n * std::mem::size_of::<$c>()];
-                reader.read(&mut bytes)?;
+                reader.read_exact(&mut bytes)?;
                 Ok(Self(unsafe { std::mem::transmute(bytes) }))
             }
         }

--- a/src/common/str/fixed.rs
+++ b/src/common/str/fixed.rs
@@ -1,121 +1,125 @@
 use std::convert::TryFrom;
-use std::io::{Read, Write};
 use std::io::Result as Res;
+use std::io::{Read, Write};
 
-use endio::{Deserialize, LE, Serialize};
+use endio::{Deserialize, Serialize, LE};
 
 use super::{AbstractLuStr, AsciiChar, AsciiError, LuChar, LuStrExt, Ucs2Char, Ucs2Error};
 
 // todo[const generics]: const generic strings
 // todo: exclude the final null terminator from the array
 macro_rules! abstract_lu_str {
-	($name:ident, $c:ty, $null:expr, $n:literal) => {
-		// todo: runtime type invariants checks (valid, null terminator)
-		/// A string with a maximum length of $n.
-		pub struct $name([$c; $n]);
+    ($name:ident, $c:ty, $null:expr, $n:literal) => {
+        // todo: runtime type invariants checks (valid, null terminator)
+        /// A string with a maximum length of $n.
+        pub struct $name([$c; $n]);
 
-		impl PartialEq for $name {
-			fn eq(&self, other: &Self) -> bool {
-				dbg!((&**self) == (&**other))
-			}
-		}
+        impl PartialEq for $name {
+            fn eq(&self, other: &Self) -> bool {
+                dbg!((&**self) == (&**other))
+            }
+        }
 
-		impl std::fmt::Debug for $name {
-			fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-				(&**self).fmt(f)
-			}
-		}
+        impl std::fmt::Debug for $name {
+            fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+                (&**self).fmt(f)
+            }
+        }
 
-		impl std::ops::Deref for $name {
-			type Target = AbstractLuStr<$c>;
+        impl std::ops::Deref for $name {
+            type Target = AbstractLuStr<$c>;
 
-			#[inline]
-			fn deref(&self) -> &Self::Target {
-				let terminator = self.0.iter().position(|&c| c == $null).unwrap();
-				&self.0[..terminator]
-			}
-		}
+            #[inline]
+            fn deref(&self) -> &Self::Target {
+                let terminator = self.0.iter().position(|&c| c == $null).unwrap();
+                &self.0[..terminator]
+            }
+        }
 
-		impl std::ops::DerefMut for $name {
-			#[inline]
-			fn deref_mut(&mut self) -> &mut Self::Target {
-				let terminator = self.0.iter().position(|&c| c == $null).unwrap();
-				&mut self.0[..terminator]
-			}
-		}
+        impl std::ops::DerefMut for $name {
+            #[inline]
+            fn deref_mut(&mut self) -> &mut Self::Target {
+                let terminator = self.0.iter().position(|&c| c == $null).unwrap();
+                &mut self.0[..terminator]
+            }
+        }
 
-		impl<R: Read> Deserialize<LE, R> for $name {
-			fn deserialize(reader: &mut R) -> Res<Self> {
-				let mut bytes = [0u8; $n*std::mem::size_of::<$c>()];
-				reader.read(&mut bytes)?;
-				Ok(Self(unsafe { std::mem::transmute(bytes) }))
-			}
-		}
+        impl<R: Read> Deserialize<LE, R> for $name {
+            fn deserialize(reader: &mut R) -> Res<Self> {
+                let mut bytes = [0u8; $n * std::mem::size_of::<$c>()];
+                reader.read(&mut bytes)?;
+                Ok(Self(unsafe { std::mem::transmute(bytes) }))
+            }
+        }
 
-		impl<W: Write> Serialize<LE, W> for &$name {
-			fn serialize(self, writer: &mut W) -> Res<()> {
-				let x: [u8; $n*std::mem::size_of::<$c>()] = unsafe { std::mem::transmute(self.0) };
-				writer.write_all(&x)
-			}
-		}
-	}
+        impl<W: Write> Serialize<LE, W> for &$name {
+            fn serialize(self, writer: &mut W) -> Res<()> {
+                let x: [u8; $n * std::mem::size_of::<$c>()] =
+                    unsafe { std::mem::transmute(self.0) };
+                writer.write_all(&x)
+            }
+        }
+    };
 }
 
 macro_rules! lu_str {
-	($name:ident, $n:literal) => {
-		abstract_lu_str!($name, AsciiChar, AsciiChar(0), $n);
+    ($name:ident, $n:literal) => {
+        abstract_lu_str!($name, AsciiChar, AsciiChar(0), $n);
 
-		impl TryFrom<&[u8]> for $name {
-			type Error = AsciiError;
+        impl TryFrom<&[u8]> for $name {
+            type Error = AsciiError;
 
-			fn try_from(string: &[u8]) -> Result<Self, Self::Error> {
-				if string.len() >= $n {
-					// actually length error but whatever
-					return Err(AsciiError);
-				}
-				let mut bytes = [0u8; $n];
-				// todo: ascii range check
-				for (i, chr) in string.iter().enumerate() {
-					bytes[i] = *chr;
-				}
-				let bytes = unsafe { std::mem::transmute(bytes) };
-				Ok(Self(bytes))
-			}
-		}
+            fn try_from(string: &[u8]) -> Result<Self, Self::Error> {
+                if string.len() >= $n {
+                    // actually length error but whatever
+                    return Err(AsciiError);
+                }
+                let mut bytes = [0u8; $n];
+                // todo: ascii range check
+                for (i, chr) in string.iter().enumerate() {
+                    bytes[i] = *chr;
+                }
+                let bytes = unsafe { std::mem::transmute(bytes) };
+                Ok(Self(bytes))
+            }
+        }
 
-		impl<const N: usize> TryFrom<&[u8; N]> for $name {
-			type Error = AsciiError;
+        impl<const N: usize> TryFrom<&[u8; N]> for $name {
+            type Error = AsciiError;
 
-			fn try_from(string: &[u8; N]) -> Result<Self, Self::Error> {
-				Self::try_from(&string[..])
-			}
-		}
-	}
+            fn try_from(string: &[u8; N]) -> Result<Self, Self::Error> {
+                Self::try_from(&string[..])
+            }
+        }
+    };
 }
 
 macro_rules! lu_wstr {
-	($name:ident, $n:literal) => {
-		abstract_lu_str!($name, Ucs2Char, Ucs2Char(0), $n);
+    ($name:ident, $n:literal) => {
+        abstract_lu_str!($name, Ucs2Char, Ucs2Char(0), $n);
 
-		impl TryFrom<&str> for $name {
-			type Error = Ucs2Error;
+        impl TryFrom<&str> for $name {
+            type Error = Ucs2Error;
 
-			fn try_from(string: &str) -> Result<Self, Self::Error> {
-				let mut bytes = [0u16; $n];
-				for (i, chr) in string.encode_utf16().take($n-1).enumerate() {
-					bytes[i] = chr;
-				}
-				let bytes = unsafe { std::mem::transmute(bytes) };
-				Ok(Self(bytes))
-			}
-		}
+            fn try_from(string: &str) -> Result<Self, Self::Error> {
+                let mut bytes = [0u16; $n];
+                for (i, chr) in string.encode_utf16().take($n - 1).enumerate() {
+                    bytes[i] = chr;
+                }
+                let bytes = unsafe { std::mem::transmute(bytes) };
+                Ok(Self(bytes))
+            }
+        }
 
-		impl From<&$name> for String {
-			fn from(wstr: &$name) -> Self {
-				String::from_utf16(unsafe {&*(&**wstr as *const [Ucs2Char] as *const [<Ucs2Char as LuChar>::Int])}).unwrap()
-			}
-		}
-	}
+        impl From<&$name> for String {
+            fn from(wstr: &$name) -> Self {
+                String::from_utf16(unsafe {
+                    &*(&**wstr as *const [Ucs2Char] as *const [<Ucs2Char as LuChar>::Int])
+                })
+                .unwrap()
+            }
+        }
+    };
 }
 
 lu_str!(LuString33, 33);

--- a/src/common/str/mod.rs
+++ b/src/common/str/mod.rs
@@ -7,8 +7,8 @@ pub use self::fixed::*;
 pub use self::variable::*;
 
 pub trait LuChar {
-	type Int;
-	type Error;
+    type Int;
+    type Error;
 }
 
 #[derive(Debug)]
@@ -23,27 +23,27 @@ pub struct AsciiChar(u8);
 pub struct Ucs2Char(u16);
 
 impl LuChar for AsciiChar {
-	type Int = u8;
-	type Error = AsciiError;
+    type Int = u8;
+    type Error = AsciiError;
 }
 
 impl LuChar for Ucs2Char {
-	type Int = u16;
-	type Error = Ucs2Error;
+    type Int = u16;
+    type Error = Ucs2Error;
 }
 
 impl From<u8> for AsciiChar {
-	fn from(byte: u8) -> Self {
-		// todo: range check
-		Self(byte)
-	}
+    fn from(byte: u8) -> Self {
+        // todo: range check
+        Self(byte)
+    }
 }
 
 impl From<u8> for Ucs2Char {
-	fn from(byte: u8) -> Self {
-		// todo: range check
-		Self(byte as u16)
-	}
+    fn from(byte: u8) -> Self {
+        // todo: range check
+        Self(byte as u16)
+    }
 }
 
 type AbstractLuStr<C> = [C];
@@ -52,46 +52,46 @@ pub type LuStr = AbstractLuStr<AsciiChar>;
 pub type LuWStr = AbstractLuStr<Ucs2Char>;
 
 pub trait LuStrExt {
-	type Char: LuChar;
+    type Char: LuChar;
 
-	fn from_slice(slice: &[<Self::Char as LuChar>::Int]) -> &[Self::Char] {
-		unsafe { &*(slice as *const [<Self::Char as LuChar>::Int] as *const [Self::Char]) }
-	}
+    fn from_slice(slice: &[<Self::Char as LuChar>::Int]) -> &[Self::Char] {
+        unsafe { &*(slice as *const [<Self::Char as LuChar>::Int] as *const [Self::Char]) }
+    }
 
-	fn as_slice(&self) -> &[<Self::Char as LuChar>::Int];
-	fn to_string(&self) -> String;
+    fn as_slice(&self) -> &[<Self::Char as LuChar>::Int];
+    fn to_string(&self) -> String;
 
-	fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error>;
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error>;
 }
 
 impl LuStrExt for LuStr {
-	type Char = AsciiChar;
+    type Char = AsciiChar;
 
-	fn as_slice(&self) -> &[<Self::Char as LuChar>::Int] {
-		unsafe { &*(self as *const [Self::Char] as *const [<Self::Char as LuChar>::Int]) }
-	}
+    fn as_slice(&self) -> &[<Self::Char as LuChar>::Int] {
+        unsafe { &*(self as *const [Self::Char] as *const [<Self::Char as LuChar>::Int]) }
+    }
 
-	fn to_string(&self) -> String {
-		std::str::from_utf8(self.as_slice()).unwrap().into()
-	}
+    fn to_string(&self) -> String {
+        std::str::from_utf8(self.as_slice()).unwrap().into()
+    }
 
-	fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-		write!(f, "b{:?}", self.to_string())
-	}
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        write!(f, "b{:?}", self.to_string())
+    }
 }
 
 impl LuStrExt for LuWStr {
-	type Char = Ucs2Char;
+    type Char = Ucs2Char;
 
-	fn as_slice(&self) -> &[<Self::Char as LuChar>::Int] {
-		unsafe { &*(self as *const [Self::Char] as *const [<Self::Char as LuChar>::Int]) }
-	}
+    fn as_slice(&self) -> &[<Self::Char as LuChar>::Int] {
+        unsafe { &*(self as *const [Self::Char] as *const [<Self::Char as LuChar>::Int]) }
+    }
 
-	fn to_string(&self) -> String {
-		String::from_utf16(self.as_slice()).unwrap()
-	}
+    fn to_string(&self) -> String {
+        String::from_utf16(self.as_slice()).unwrap()
+    }
 
-	fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-		write!(f, "{:?}", self.to_string())
-	}
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        write!(f, "{:?}", self.to_string())
+    }
 }

--- a/src/common/str/variable.rs
+++ b/src/common/str/variable.rs
@@ -9,25 +9,25 @@ pub type LuVarWString<L> = LVec<L, Ucs2Char>;
 
 impl<L> std::fmt::Debug for LuVarString<L> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-        (&**self).fmt(f)
+        (**self).fmt(f)
     }
 }
 
 impl<L> std::fmt::Debug for LuVarWString<L> {
     fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-        (&**self).fmt(f)
+        (**self).fmt(f)
     }
 }
 
 impl<L> From<&LuVarString<L>> for String {
     fn from(string: &LuVarString<L>) -> String {
-        (&**string).to_string()
+        (**string).to_string()
     }
 }
 
 impl<L> From<&LuVarWString<L>> for String {
     fn from(string: &LuVarWString<L>) -> String {
-        (&**string).to_string()
+        (**string).to_string()
     }
 }
 

--- a/src/common/str/variable.rs
+++ b/src/common/str/variable.rs
@@ -1,66 +1,69 @@
-use std::convert::{TryFrom};
+use std::convert::TryFrom;
 use std::marker::PhantomData;
 
-use crate::common::LVec;
 use super::{AsciiChar, AsciiError, LuStrExt, LuWStr, Ucs2Char, Ucs2Error};
+use crate::common::LVec;
 
 pub type LuVarString<L> = LVec<L, AsciiChar>;
 pub type LuVarWString<L> = LVec<L, Ucs2Char>;
 
 impl<L> std::fmt::Debug for LuVarString<L> {
-	fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-		(&**self).fmt(f)
-	}
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        (&**self).fmt(f)
+    }
 }
 
 impl<L> std::fmt::Debug for LuVarWString<L> {
-	fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-		(&**self).fmt(f)
-	}
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        (&**self).fmt(f)
+    }
 }
 
 impl<L> From<&LuVarString<L>> for String {
-	fn from(string: &LuVarString<L>) -> String {
-		(&**string).to_string()
-	}
+    fn from(string: &LuVarString<L>) -> String {
+        (&**string).to_string()
+    }
 }
 
 impl<L> From<&LuVarWString<L>> for String {
-	fn from(string: &LuVarWString<L>) -> String {
-		(&**string).to_string()
-	}
+    fn from(string: &LuVarWString<L>) -> String {
+        (&**string).to_string()
+    }
 }
 
 impl<L> TryFrom<&[u8]> for LuVarString<L> {
-	type Error = AsciiError;
+    type Error = AsciiError;
 
-	fn try_from(string: &[u8]) -> Result<Self, Self::Error> {
-		// todo: check for invalid character ranges for ascii
-		Ok(Self(unsafe { (&*(string as *const [u8] as *const [AsciiChar])).into() }, PhantomData))
-	}
+    fn try_from(string: &[u8]) -> Result<Self, Self::Error> {
+        // todo: check for invalid character ranges for ascii
+        Ok(Self(
+            unsafe { (&*(string as *const [u8] as *const [AsciiChar])).into() },
+            PhantomData,
+        ))
+    }
 }
 
 impl<L, const N: usize> TryFrom<&[u8; N]> for LuVarString<L> {
-	type Error = AsciiError;
+    type Error = AsciiError;
 
-	fn try_from(string: &[u8; N]) -> Result<Self, Self::Error> {
-		Self::try_from(&string[..])
-	}
+    fn try_from(string: &[u8; N]) -> Result<Self, Self::Error> {
+        Self::try_from(&string[..])
+    }
 }
 
 impl<L> From<&LuWStr> for LuVarWString<L> {
-	fn from(string: &LuWStr) -> Self {
-		Self(string.into(), PhantomData)
-	}
+    fn from(string: &LuWStr) -> Self {
+        Self(string.into(), PhantomData)
+    }
 }
 
 impl<L> TryFrom<&str> for LuVarWString<L> {
-	type Error = Ucs2Error;
+    type Error = Ucs2Error;
 
-	fn try_from(string: &str) -> Result<Self, Self::Error> {
-		let chars: Vec<u16> = string.encode_utf16().collect();
-		// todo: check for invalid character ranges for ucs 2
-		let chars = unsafe { std::mem::transmute(chars) };
-		Ok(Self(chars, PhantomData))
-	}
+    fn try_from(string: &str) -> Result<Self, Self::Error> {
+        let chars: Vec<u16> = string.encode_utf16().collect();
+        // todo: check for invalid character ranges for ucs 2
+        let chars = unsafe { std::mem::transmute(chars) };
+        Ok(Self(chars, PhantomData))
+    }
 }

--- a/src/general/client/mod.rs
+++ b/src/general/client/mod.rs
@@ -6,84 +6,84 @@ use crate::common::ServiceId;
 
 /// Client-received general messages.
 #[derive(Debug, Deserialize, PartialEq, Serialize, VariantTests)]
-#[post_disc_padding=1]
+#[post_disc_padding = 1]
 #[repr(u32)]
 pub enum GeneralMessage {
-	Handshake(Handshake),
-	DisconnectNotify(DisconnectNotify),
+    Handshake(Handshake),
+    DisconnectNotify(DisconnectNotify),
 }
 
 /**
-	Completes a version handshake initiated by the client.
+    Completes a version handshake initiated by the client.
 
-	### Trigger
-	Receipt of a client-sent [`Handshake`](super::server::Handshake) packet that was acceptable to the server.
+    ### Trigger
+    Receipt of a client-sent [`Handshake`](super::server::Handshake) packet that was acceptable to the server.
 
-	### Handling
-	Optionally check if the server's [`network_version`](Self::network_version) matches your own. You can usually assume that the server will check this itself and disconnect if it doesn't match, but you can check again to be sure.
+    ### Handling
+    Optionally check if the server's [`network_version`](Self::network_version) matches your own. You can usually assume that the server will check this itself and disconnect if it doesn't match, but you can check again to be sure.
 
-	### Response
-	If the server's [`service_id`](Self::service_id) is [`ServiceId::Auth`], respond with a [`LoginRequest`](crate::auth::server::LoginRequest) with your username and password. If it is [`ServiceId::World`], send a [`ClientValidation`](crate::world::server::ClientValidation) with your username and the session key provided by auth.
+    ### Response
+    If the server's [`service_id`](Self::service_id) is [`ServiceId::Auth`], respond with a [`LoginRequest`](crate::auth::server::LoginRequest) with your username and password. If it is [`ServiceId::World`], send a [`ClientValidation`](crate::world::server::ClientValidation) with your username and the session key provided by auth.
 
-	### Notes
-	As the version confirm process was designed with more than just client-server in mind, it sends the server's network version and service id as well, even though this isn't really needed by the client (even the service id isn't needed, since you usually only connect to auth once, and it's the very first connection). This could be simplified if the protocol is ever revised.
+    ### Notes
+    As the version confirm process was designed with more than just client-server in mind, it sends the server's network version and service id as well, even though this isn't really needed by the client (even the service id isn't needed, since you usually only connect to auth once, and it's the very first connection). This could be simplified if the protocol is ever revised.
 */
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
-#[trailing_padding=41]
+#[trailing_padding = 41]
 pub struct Handshake {
-	/// The network protocol version of the server. For servers compatible with live, this is `171022`. This was relevant mainly back when LU was actively updated. Server projects making modifications to the network protocol should set this to a different value.
-	pub network_version: u32,
-	/// Service ID of the server, [`ServiceId::Auth`] for auth servers, [`ServiceId::World`] for world servers.
-	#[padding=4]
-	pub service_id: ServiceId,
+    /// The network protocol version of the server. For servers compatible with live, this is `171022`. This was relevant mainly back when LU was actively updated. Server projects making modifications to the network protocol should set this to a different value.
+    pub network_version: u32,
+    /// Service ID of the server, [`ServiceId::Auth`] for auth servers, [`ServiceId::World`] for world servers.
+    #[padding = 4]
+    pub service_id: ServiceId,
 }
 
 /**
-	Notifies the client when it was actively disconnected by the server.
+    Notifies the client when it was actively disconnected by the server.
 
-	### Trigger
-	Being disconnected by the server, the exact trigger depends on the variant.
+    ### Trigger
+    Being disconnected by the server, the exact trigger depends on the variant.
 
-	### Handling
-	Display a message to the user.
+    ### Handling
+    Display a message to the user.
 
-	### Response
-	None. Expect the connection to be closed shortly after, so a response won't even be possible.
+    ### Response
+    None. Expect the connection to be closed shortly after, so a response won't even be possible.
 
-	### Notes
-	You can be disconnected without receiving this packet, for example when your connection is lost. The server is also not obligated to send this packet and may disconnect you without doing so.
+    ### Notes
+    You can be disconnected without receiving this packet, for example when your connection is lost. The server is also not obligated to send this packet and may disconnect you without doing so.
 */
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[repr(u32)]
 pub enum DisconnectNotify {
-	/// Unspecified disconnect reason.
-	UnknownServerError,
-	/// The client's [`network_version`](super::server::Handshake::network_version) did not match the server's [`network_version`](Handshake::network_version). The message contains the server network version number.
-	WrongGameVersion(u32),
-	/// Unused for client-server.
-	WrongServerVersion(u32),
-	/// Connection attempt on invalid port, server emulators probably won't send this as they usually won't have server-server communication using LU's protocol.
-	ConnectionOnInvalidPort,
-	/// There was another login with your account and your session has been closed in favor of the new login.
-	DuplicateLogin,
-	/// The server is shutting down.
-	ServerShutdown,
-	/// No server hosting this map is available.
-	UnableToLoadMap,
-	/// The provided [`ClientValidation::session_key`](crate::world::server::ClientValidation::session_key) is incorrect.
-	InvalidSessionKey,
-	/// Server did not expect a [`ClientValidation`](crate::world::server::ClientValidation) at this time.
-	AccountNotInPendingList,
-	/// The provided [`CharacterLoginRequest::char_id`](crate::world::server::CharacterLoginRequest::char_id) was not a valid character ID of this account.
-	CharacterNotFound,
-	/// The character seems to be corrupted in the database.
-	CharacterCorruption,
-	/// You were kicked from the server.
-	Kick,
-	/// Error saving or loading progress.
-	SaveFailure,
-	/// The account's time-limited free trial expired, unused.
-	FreeTrialExpired,
-	/// The parental controls for this account prevent it from further play.
-	PlayScheduleTimeUp,
+    /// Unspecified disconnect reason.
+    UnknownServerError,
+    /// The client's [`network_version`](super::server::Handshake::network_version) did not match the server's [`network_version`](Handshake::network_version). The message contains the server network version number.
+    WrongGameVersion(u32),
+    /// Unused for client-server.
+    WrongServerVersion(u32),
+    /// Connection attempt on invalid port, server emulators probably won't send this as they usually won't have server-server communication using LU's protocol.
+    ConnectionOnInvalidPort,
+    /// There was another login with your account and your session has been closed in favor of the new login.
+    DuplicateLogin,
+    /// The server is shutting down.
+    ServerShutdown,
+    /// No server hosting this map is available.
+    UnableToLoadMap,
+    /// The provided [`ClientValidation::session_key`](crate::world::server::ClientValidation::session_key) is incorrect.
+    InvalidSessionKey,
+    /// Server did not expect a [`ClientValidation`](crate::world::server::ClientValidation) at this time.
+    AccountNotInPendingList,
+    /// The provided [`CharacterLoginRequest::char_id`](crate::world::server::CharacterLoginRequest::char_id) was not a valid character ID of this account.
+    CharacterNotFound,
+    /// The character seems to be corrupted in the database.
+    CharacterCorruption,
+    /// You were kicked from the server.
+    Kick,
+    /// Error saving or loading progress.
+    SaveFailure,
+    /// The account's time-limited free trial expired, unused.
+    FreeTrialExpired,
+    /// The parental controls for this account prevent it from further play.
+    PlayScheduleTimeUp,
 }

--- a/src/general/server/mod.rs
+++ b/src/general/server/mod.rs
@@ -5,40 +5,40 @@ use lu_packets_derive::VariantTests;
 use crate::common::ServiceId;
 
 #[derive(Debug, Deserialize, PartialEq, Serialize, VariantTests)]
-#[post_disc_padding=1]
+#[post_disc_padding = 1]
 #[repr(u32)]
 pub enum GeneralMessage {
-	Handshake(Handshake)
+    Handshake(Handshake),
 }
 
 /**
-	Provides the client's network version.
+    Provides the client's network version.
 
-	Allows to identify outdated clients and disconnect them early.
+    Allows to identify outdated clients and disconnect them early.
 
-	### Trigger
-	Establishment of raknet connection (receipt of [`ConnectionRequestAccepted`](crate::raknet::client::ConnectionRequestAccepted)).
+    ### Trigger
+    Establishment of raknet connection (receipt of [`ConnectionRequestAccepted`](crate::raknet::client::ConnectionRequestAccepted)).
 
-	### Handling
-	Check if [`network_version`](Self::network_version) matches the version you expect. Otherwise, disconnect the client, ideally with a [`DisconnectNotify::InvalidGameVersion`](super::client::DisconnectNotify::WrongGameVersion) specifying the expected version.
+    ### Handling
+    Check if [`network_version`](Self::network_version) matches the version you expect. Otherwise, disconnect the client, ideally with a [`DisconnectNotify::InvalidGameVersion`](super::client::DisconnectNotify::WrongGameVersion) specifying the expected version.
 
-	### Response
-	Respond with a server-sent [`Handshake`](super::client::Handshake) providing the server's network version and service ID.
+    ### Response
+    Respond with a server-sent [`Handshake`](super::client::Handshake) providing the server's network version and service ID.
 
-	### Notes
-	This packet should not be seen as proof that the client's network version is actually what they report it to be. The client can provide any value, and malicious clients can deviate from the protocol in any way they like. Therefore, proper length and value checking is still required for packet parsing, and care should be taken that your server does not crash on invalid input. If you're using the parsing functionality of this library, this will be taken care of for you.
+    ### Notes
+    This packet should not be seen as proof that the client's network version is actually what they report it to be. The client can provide any value, and malicious clients can deviate from the protocol in any way they like. Therefore, proper length and value checking is still required for packet parsing, and care should be taken that your server does not crash on invalid input. If you're using the parsing functionality of this library, this will be taken care of for you.
 */
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
-#[trailing_padding=33]
+#[trailing_padding = 33]
 pub struct Handshake {
-	/// The network protocol version of the client. For unmodified live clients, this is `171022`. This was relevant mainly back when LU was actively updated. If you intend to make modifications to the protocol for your server project, you should change this to a different value.
-	pub network_version: u32,
-	#[padding=4]
-	/// Service ID of the client, always [`ServiceId::Client`]. LU used this packet for all service communications, including server-to-server, which is the reason it's necessary to specify this.
-	pub service_id: ServiceId,
-	#[padding=2]
-	/// Process ID of the client.
-	pub process_id: u32,
-	/// Local port of the client, not necessarily the same as the one the connection is from in case of NAT.
-	pub port: u16,
+    /// The network protocol version of the client. For unmodified live clients, this is `171022`. This was relevant mainly back when LU was actively updated. If you intend to make modifications to the protocol for your server project, you should change this to a different value.
+    pub network_version: u32,
+    #[padding = 4]
+    /// Service ID of the client, always [`ServiceId::Client`]. LU used this packet for all service communications, including server-to-server, which is the reason it's necessary to specify this.
+    pub service_id: ServiceId,
+    #[padding = 2]
+    /// Process ID of the client.
+    pub process_id: u32,
+    /// Local port of the client, not necessarily the same as the one the connection is from in case of NAT.
+    pub port: u16,
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,51 +1,51 @@
 /*!
-	Documentation and (de-)serialization support for LU's network protocol.
+    Documentation and (de-)serialization support for LU's network protocol.
 */
 #![feature(specialization)]
 #![allow(incomplete_features)]
 
 /**
-	Creates an [`Amf3::Array`](crate::world::amf3::Amf3::Array) containing the arguments.
+    Creates an [`Amf3::Array`](crate::world::amf3::Amf3::Array) containing the arguments.
 
-	Since AMF3 arrays are both vectors and maps at the same time, there are multiple forms of the macro, for map and for vector usage.
+    Since AMF3 arrays are both vectors and maps at the same time, there are multiple forms of the macro, for map and for vector usage.
 
-	### Map usage
+    ### Map usage
 
-	The syntax is `name: value`, where `name` is a string literal that will be converted to an [`Amf3String`](crate::world::amf3::Amf3String), and `value` is an expression that will be converted to an [`Amf3`] object.
+    The syntax is `name: value`, where `name` is a string literal that will be converted to an [`Amf3String`](crate::world::amf3::Amf3String), and `value` is an expression that will be converted to an [`Amf3`] object.
 
-	Example:
+    Example:
 
-	```
-	# #[macro_use] extern crate lu_packets;
-	# use lu_packets::amf3;
-	# fn main() {
-	amf3! {
-		"false": false,
-		"true": true,
-		"double1": 3.14f32,
-		"double2": 3.14f64,
-		"string": "string",
-		"array": amf3! { "inner": "array"},
-	};
-	# }
-	```
+    ```
+    # #[macro_use] extern crate lu_packets;
+    # use lu_packets::amf3;
+    # fn main() {
+    amf3! {
+        "false": false,
+        "true": true,
+        "double1": 3.14f32,
+        "double2": 3.14f64,
+        "string": "string",
+        "array": amf3! { "inner": "array"},
+    };
+    # }
+    ```
 
-	### Vector usage
+    ### Vector usage
 
-	The syntax is the exact same as with the [`vec!`] macro, except that the arguments will be converted to an [`Amf3`] object before being inserted.
+    The syntax is the exact same as with the [`vec!`] macro, except that the arguments will be converted to an [`Amf3`] object before being inserted.
 
-	Example:
+    Example:
 
-	```
-	# #[macro_use] extern crate lu_packets;
-	# use lu_packets::amf3;
-	# fn main() {
-	amf3! [true, false, true];
-	amf3! [true; 4];
-	# }
-	```
+    ```
+    # #[macro_use] extern crate lu_packets;
+    # use lu_packets::amf3;
+    # fn main() {
+    amf3! [true, false, true];
+    amf3! [true; 4];
+    # }
+    ```
 
-	[`Amf3`]: crate::world::amf3::Amf3
+    [`Amf3`]: crate::world::amf3::Amf3
 */
 #[macro_export]
 macro_rules! amf3 {
@@ -77,35 +77,35 @@ macro_rules! amf3 {
 }
 
 /**
-	Creates a [`LuNameValue`] containing the arguments.
+    Creates a [`LuNameValue`] containing the arguments.
 
-	The syntax is `name: value`, where `name` is a string literal that will be converted to a [`LuVarWString<u32>`], and `value` is an expression that will be converted to an [`LnvValue`].
+    The syntax is `name: value`, where `name` is a string literal that will be converted to a [`LuVarWString<u32>`], and `value` is an expression that will be converted to an [`LnvValue`].
 
-	Example:
+    Example:
 
-	```
-	# #[macro_use] extern crate lu_packets;
-	# use lu_packets::lnv;
-	# fn main() {
-	lnv! {
-		"wstring": "string expression",
-		"i32": 42i32,
-		"f32": 3.14f32,
-		"f64": 3.14f64,
-		"u32": 42u32,
-		"bool": true,
-		"i64": i64::MAX,
-		"u64": u64::MAX,
-		"string": b"byte slice",
-	};
-	# }
-	```
+    ```
+    # #[macro_use] extern crate lu_packets;
+    # use lu_packets::lnv;
+    # fn main() {
+    lnv! {
+        "wstring": "string expression",
+        "i32": 42i32,
+        "f32": 3.14f32,
+        "f64": 3.14f64,
+        "u32": 42u32,
+        "bool": true,
+        "i64": i64::MAX,
+        "u64": u64::MAX,
+        "string": b"byte slice",
+    };
+    # }
+    ```
 
-	Care should be taken with integer and float literals to suffix them with the correct type, as seen above. Rust assumes `i32` for integer and `f64` for float literals by default, which may not be what you want, and can lead to incorrect serialization.
+    Care should be taken with integer and float literals to suffix them with the correct type, as seen above. Rust assumes `i32` for integer and `f64` for float literals by default, which may not be what you want, and can lead to incorrect serialization.
 
-	[`LuNameValue`]: crate::world::LuNameValue
-	[`LuVarWString<u32>`]: crate::common::LuVarWString
-	[`LnvValue`]: crate::world::LnvValue
+    [`LuNameValue`]: crate::world::LuNameValue
+    [`LuVarWString<u32>`]: crate::common::LuVarWString
+    [`LnvValue`]: crate::world::LnvValue
 */
 #[macro_export]
 macro_rules! lnv {
@@ -120,22 +120,22 @@ macro_rules! lnv {
 }
 
 /**
-	Converts the argument to a LU string.
+    Converts the argument to a LU string.
 
-	This forwards to the [`TryInto`] implementation on the argument, which means the macro is flexible and works with both string and wstring types, and both fixed and variable types, depending on context. Generally, to convert to a string type, pass a byte slice, and for a wstring type, pass a `&str` or `String`.
+    This forwards to the [`TryInto`] implementation on the argument, which means the macro is flexible and works with both string and wstring types, and both fixed and variable types, depending on context. Generally, to convert to a string type, pass a byte slice, and for a wstring type, pass a `&str` or `String`.
 
-	[`TryInto`]: std::convert::TryInto
+    [`TryInto`]: std::convert::TryInto
 */
 #[macro_export]
 macro_rules! lu {
-	($str_lit:expr) => {
-		::std::convert::TryInto::try_into($str_lit).unwrap()
-	}
+    ($str_lit:expr) => {
+        ::std::convert::TryInto::try_into($str_lit).unwrap()
+    };
 }
 
-pub mod raknet;
 pub mod auth;
 pub mod chat;
 pub mod common;
 pub mod general;
+pub mod raknet;
 pub mod world;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,6 +3,9 @@
 */
 #![feature(specialization)]
 #![allow(incomplete_features)]
+#![allow(clippy::large_enum_variant)]
+#![allow(clippy::uninlined_format_args)]
+#![allow(clippy::type_complexity)]
 
 /**
     Creates an [`Amf3::Array`](crate::world::amf3::Amf3::Array) containing the arguments.

--- a/src/raknet/client/mod.rs
+++ b/src/raknet/client/mod.rs
@@ -12,46 +12,46 @@ use replica::{ReplicaConstruction, ReplicaSerialization};
 #[non_exhaustive]
 #[repr(u8)]
 pub enum Message<U> {
-	ConnectedPong(ConnectedPong) = 3,
-	ConnectionRequestAccepted(ConnectionRequestAccepted) = 14,
-	DisconnectionNotification = 19,
-	ReplicaConstruction(ReplicaConstruction) = 36,
-	ReplicaSerialization(ReplicaSerialization) = 39,
-	UserMessage(U) = 83,
+    ConnectedPong(ConnectedPong) = 3,
+    ConnectionRequestAccepted(ConnectionRequestAccepted) = 14,
+    DisconnectionNotification = 19,
+    ReplicaConstruction(ReplicaConstruction) = 36,
+    ReplicaSerialization(ReplicaSerialization) = 39,
+    UserMessage(U) = 83,
 }
 
 impl<U> From<ConnectedPong> for Message<U> {
-	fn from(msg: ConnectedPong) -> Self {
-		Message::ConnectedPong(msg)
-	}
+    fn from(msg: ConnectedPong) -> Self {
+        Message::ConnectedPong(msg)
+    }
 }
 
 impl<U> From<ConnectionRequestAccepted> for Message<U> {
-	fn from(msg: ConnectionRequestAccepted) -> Self {
-		Message::ConnectionRequestAccepted(msg)
-	}
+    fn from(msg: ConnectionRequestAccepted) -> Self {
+        Message::ConnectionRequestAccepted(msg)
+    }
 }
 
 impl<U> From<ReplicaConstruction> for Message<U> {
-	fn from(msg: ReplicaConstruction) -> Self {
-		Message::ReplicaConstruction(msg)
-	}
+    fn from(msg: ReplicaConstruction) -> Self {
+        Message::ReplicaConstruction(msg)
+    }
 }
 
 impl<U> From<ReplicaSerialization> for Message<U> {
-	fn from(msg: ReplicaSerialization) -> Self {
-		Message::ReplicaSerialization(msg)
-	}
+    fn from(msg: ReplicaSerialization) -> Self {
+        Message::ReplicaSerialization(msg)
+    }
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct ConnectedPong {
-	pub ping_send_time: u32,
+    pub ping_send_time: u32,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct ConnectionRequestAccepted {
-	pub peer_addr: SystemAddress,
-	#[padding=2]
-	pub local_addr: SystemAddress,
+    pub peer_addr: SystemAddress,
+    #[padding = 2]
+    pub local_addr: SystemAddress,
 }

--- a/src/raknet/client/replica/achievement_vendor.rs
+++ b/src/raknet/client/replica/achievement_vendor.rs
@@ -4,31 +4,31 @@ use endio::Serialize;
 use endio_bit::BEBitWriter;
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
-use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
 use super::vendor::VendorInfo;
+use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct AchievementVendorConstruction {
-	pub vendor_info: Option<VendorInfo>,
+    pub vendor_info: Option<VendorInfo>,
 }
 
 impl ComponentConstruction for AchievementVendorConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub type AchievementVendorSerialization = AchievementVendorConstruction;
 
 impl ComponentSerialization for AchievementVendorSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct AchievementVendorProtocol;
 
 impl ComponentProtocol for AchievementVendorProtocol {
-	type Construction = AchievementVendorConstruction;
-	type Serialization = AchievementVendorSerialization;
+    type Construction = AchievementVendorConstruction;
+    type Serialization = AchievementVendorSerialization;
 }

--- a/src/raknet/client/replica/base_combat_ai.rs
+++ b/src/raknet/client/replica/base_combat_ai.rs
@@ -4,47 +4,47 @@ use endio::{Deserialize, Serialize};
 use endio_bit::BEBitWriter;
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
-use crate::common::ObjId;
 use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
+use crate::common::ObjId;
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[repr(u32)]
 pub enum AiCombatState {
-	Idle,
-	Aggro,
-	ReturningToTether,
-	Spawn,
-	Dead,
+    Idle,
+    Aggro,
+    ReturningToTether,
+    Spawn,
+    Dead,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct CombatAiInfo {
-	pub current_combat_state: AiCombatState,
-	pub current_target: ObjId,
+    pub current_combat_state: AiCombatState,
+    pub current_target: ObjId,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct BaseCombatAiConstruction {
-	pub combat_ai_info: Option<CombatAiInfo>,
+    pub combat_ai_info: Option<CombatAiInfo>,
 }
 
 impl ComponentConstruction for BaseCombatAiConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub type BaseCombatAiSerialization = BaseCombatAiConstruction;
 
 impl ComponentSerialization for BaseCombatAiSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct BaseCombatAiProtocol;
 
 impl ComponentProtocol for BaseCombatAiProtocol {
-	type Construction = BaseCombatAiConstruction;
-	type Serialization = BaseCombatAiSerialization;
+    type Construction = BaseCombatAiConstruction;
+    type Serialization = BaseCombatAiSerialization;
 }

--- a/src/raknet/client/replica/bbb.rs
+++ b/src/raknet/client/replica/bbb.rs
@@ -4,31 +4,31 @@ use endio::Serialize;
 use endio_bit::BEBitWriter;
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
-use crate::common::ObjId;
 use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
+use crate::common::ObjId;
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct BbbConstruction {
-	pub metadata_source_item: Option<ObjId>,
+    pub metadata_source_item: Option<ObjId>,
 }
 
 impl ComponentConstruction for BbbConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub type BbbSerialization = BbbConstruction;
 
 impl ComponentSerialization for BbbSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct BbbProtocol;
 
 impl ComponentProtocol for BbbProtocol {
-	type Construction = BbbConstruction;
-	type Serialization = BbbSerialization;
+    type Construction = BbbConstruction;
+    type Serialization = BbbSerialization;
 }

--- a/src/raknet/client/replica/bouncer.rs
+++ b/src/raknet/client/replica/bouncer.rs
@@ -8,26 +8,26 @@ use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct BouncerConstruction {
-	pub bounce_on_collision: Option<bool>,
+    pub bounce_on_collision: Option<bool>,
 }
 
 impl ComponentConstruction for BouncerConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub type BouncerSerialization = BouncerConstruction;
 
 impl ComponentSerialization for BouncerSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct BouncerProtocol;
 
 impl ComponentProtocol for BouncerProtocol {
-	type Construction = BouncerConstruction;
-	type Serialization = BouncerSerialization;
+    type Construction = BouncerConstruction;
+    type Serialization = BouncerSerialization;
 }

--- a/src/raknet/client/replica/buff.rs
+++ b/src/raknet/client/replica/buff.rs
@@ -1,114 +1,113 @@
 use std::io::{Read, Result as Res, Write};
 
-use endio::{Deserialize, LE, LERead, LEWrite, Serialize};
+use endio::{Deserialize, LERead, LEWrite, Serialize, LE};
 use endio_bit::{BEBitReader, BEBitWriter};
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
+use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization, ReplicaD};
 use crate::common::{LVec, ObjId};
-use super::{ReplicaD, ComponentConstruction, ComponentProtocol, ComponentSerialization};
 
 // so close to being able to do serialization automatically...if not for the irregularity with `added_by_teammate`...
 #[derive(Debug, PartialEq)]
 pub struct BuffInfo {
-	pub buff_id: u32,
-	pub time_left: Option<u32>,
-	pub cancel_on_death: bool,
-	pub cancel_on_zone: bool,
-	pub cancel_on_damaged: bool,
-	pub cancel_on_remove_buff: bool,
-	pub cancel_on_ui: bool,
-	pub cancel_on_logout: bool,
-	pub cancel_on_unequip: bool,
-	pub cancel_on_damage_absorb_ran_out: bool,
-	pub added_by_teammate: Option<ObjId>,
-	pub apply_on_teammates: bool,
-	pub ref_count: i32,
+    pub buff_id: u32,
+    pub time_left: Option<u32>,
+    pub cancel_on_death: bool,
+    pub cancel_on_zone: bool,
+    pub cancel_on_damaged: bool,
+    pub cancel_on_remove_buff: bool,
+    pub cancel_on_ui: bool,
+    pub cancel_on_logout: bool,
+    pub cancel_on_unequip: bool,
+    pub cancel_on_damage_absorb_ran_out: bool,
+    pub added_by_teammate: Option<ObjId>,
+    pub apply_on_teammates: bool,
+    pub ref_count: i32,
 }
 
 impl<R: Read> Deserialize<LE, BEBitReader<R>> for BuffInfo {
-	fn deserialize(reader: &mut BEBitReader<R>) -> Res<Self> {
-		let buff_id = LERead::read(reader)?;
-		let time_left = ReplicaD::deserialize(reader)?;
-		let cancel_on_death = reader.read_bit()?;
-		let cancel_on_zone = reader.read_bit()?;
-		let cancel_on_damaged = reader.read_bit()?;
-		let cancel_on_remove_buff = reader.read_bit()?;
-		let cancel_on_ui = reader.read_bit()?;
-		let cancel_on_logout = reader.read_bit()?;
-		let cancel_on_unequip = reader.read_bit()?;
-		let cancel_on_damage_absorb_ran_out = reader.read_bit()?;
-		let added_by_teammate = reader.read_bit()?;
-		let apply_on_teammates = reader.read_bit()?;
-		let added_by_teammate = if added_by_teammate {
-			Some(LERead::read(reader)?)
-		} else {
-			None
-		};
-		let ref_count = LERead::read(reader)?;
-		Ok(Self {
-				buff_id,
-				time_left,
-				cancel_on_death,
-				cancel_on_zone,
-				cancel_on_damaged,
-				cancel_on_remove_buff,
-				cancel_on_ui,
-				cancel_on_logout,
-				cancel_on_unequip,
-				cancel_on_damage_absorb_ran_out,
-				added_by_teammate,
-				apply_on_teammates,
-				ref_count,
-		})
-	}
+    fn deserialize(reader: &mut BEBitReader<R>) -> Res<Self> {
+        let buff_id = LERead::read(reader)?;
+        let time_left = ReplicaD::deserialize(reader)?;
+        let cancel_on_death = reader.read_bit()?;
+        let cancel_on_zone = reader.read_bit()?;
+        let cancel_on_damaged = reader.read_bit()?;
+        let cancel_on_remove_buff = reader.read_bit()?;
+        let cancel_on_ui = reader.read_bit()?;
+        let cancel_on_logout = reader.read_bit()?;
+        let cancel_on_unequip = reader.read_bit()?;
+        let cancel_on_damage_absorb_ran_out = reader.read_bit()?;
+        let added_by_teammate = reader.read_bit()?;
+        let apply_on_teammates = reader.read_bit()?;
+        let added_by_teammate = if added_by_teammate {
+            Some(LERead::read(reader)?)
+        } else {
+            None
+        };
+        let ref_count = LERead::read(reader)?;
+        Ok(Self {
+            buff_id,
+            time_left,
+            cancel_on_death,
+            cancel_on_zone,
+            cancel_on_damaged,
+            cancel_on_remove_buff,
+            cancel_on_ui,
+            cancel_on_logout,
+            cancel_on_unequip,
+            cancel_on_damage_absorb_ran_out,
+            added_by_teammate,
+            apply_on_teammates,
+            ref_count,
+        })
+    }
 }
 impl<'a, W: Write> Serialize<LE, BEBitWriter<W>> for &'a BuffInfo {
-	fn serialize(self, writer: &mut BEBitWriter<W>) -> Res<()> {
-		LEWrite::write(writer, self.buff_id)?;
-		crate::raknet::client::replica::ReplicaS::serialize(&self.time_left, writer)?;
-		writer.write_bit(self.cancel_on_death)?;
-		writer.write_bit(self.cancel_on_zone)?;
-		writer.write_bit(self.cancel_on_damaged)?;
-		writer.write_bit(self.cancel_on_remove_buff)?;
-		writer.write_bit(self.cancel_on_ui)?;
-		writer.write_bit(self.cancel_on_logout)?;
-		writer.write_bit(self.cancel_on_unequip)?;
-		writer.write_bit(self.cancel_on_damage_absorb_ran_out)?;
-		writer.write_bit(self.added_by_teammate.is_some())?;
-		writer.write_bit(self.apply_on_teammates)?;
-		if let Some(x) = self.added_by_teammate {
-			LEWrite::write(writer, x)?;
-		}
-		LEWrite::write(writer, self.ref_count)?;
-		Ok(())
-	}
+    fn serialize(self, writer: &mut BEBitWriter<W>) -> Res<()> {
+        LEWrite::write(writer, self.buff_id)?;
+        crate::raknet::client::replica::ReplicaS::serialize(&self.time_left, writer)?;
+        writer.write_bit(self.cancel_on_death)?;
+        writer.write_bit(self.cancel_on_zone)?;
+        writer.write_bit(self.cancel_on_damaged)?;
+        writer.write_bit(self.cancel_on_remove_buff)?;
+        writer.write_bit(self.cancel_on_ui)?;
+        writer.write_bit(self.cancel_on_logout)?;
+        writer.write_bit(self.cancel_on_unequip)?;
+        writer.write_bit(self.cancel_on_damage_absorb_ran_out)?;
+        writer.write_bit(self.added_by_teammate.is_some())?;
+        writer.write_bit(self.apply_on_teammates)?;
+        if let Some(x) = self.added_by_teammate {
+            LEWrite::write(writer, x)?;
+        }
+        LEWrite::write(writer, self.ref_count)?;
+        Ok(())
+    }
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct BuffConstruction {
-	pub buffs: Option<LVec<u32, BuffInfo>>,
-	pub immunities: Option<LVec<u32, BuffInfo>>,
+    pub buffs: Option<LVec<u32, BuffInfo>>,
+    pub immunities: Option<LVec<u32, BuffInfo>>,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
-pub struct BuffSerialization {
-}
+pub struct BuffSerialization {}
 
 impl ComponentConstruction for BuffConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 impl ComponentSerialization for BuffSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct BuffProtocol;
 
 impl ComponentProtocol for BuffProtocol {
-	type Construction = BuffConstruction;
-	type Serialization = BuffSerialization;
+    type Construction = BuffConstruction;
+    type Serialization = BuffSerialization;
 }

--- a/src/raknet/client/replica/character.rs
+++ b/src/raknet/client/replica/character.rs
@@ -1,146 +1,160 @@
 use std::io::{Error, ErrorKind::InvalidData, Read, Result as Res, Write};
 
-use endio::{Deserialize, LE, LERead, LEWrite, Serialize};
+use endio::{Deserialize, LERead, LEWrite, Serialize, LE};
 use endio_bit::{BEBitReader, BEBitWriter};
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
-use crate::common::{LuVarWString, ObjId};
 use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
+use crate::common::{LuVarWString, ObjId};
 
 #[derive(Debug, PartialEq)]
 pub enum TransitionState {
-	None,
-	Arrive { last_custom_build_parts: LuVarWString<u16> },
-	Leave,
+    None,
+    Arrive {
+        last_custom_build_parts: LuVarWString<u16>,
+    },
+    Leave,
 }
 
 impl<R: Read> Deserialize<LE, BEBitReader<R>> for TransitionState {
-	fn deserialize(reader: &mut BEBitReader<R>) -> Res<Self> {
-		let disc = reader.read_bits(2)?;
-		Ok(match disc {
-			0 => TransitionState::None,
-			1 => TransitionState::Arrive { last_custom_build_parts: LERead::read(reader)? },
-			2 => TransitionState::Leave,
-			_ => { return Err(Error::new(InvalidData, "invalid discriminant for TransitionState")) }
-		})
-	}
+    fn deserialize(reader: &mut BEBitReader<R>) -> Res<Self> {
+        let disc = reader.read_bits(2)?;
+        Ok(match disc {
+            0 => TransitionState::None,
+            1 => TransitionState::Arrive {
+                last_custom_build_parts: LERead::read(reader)?,
+            },
+            2 => TransitionState::Leave,
+            _ => {
+                return Err(Error::new(
+                    InvalidData,
+                    "invalid discriminant for TransitionState",
+                ))
+            }
+        })
+    }
 }
 
 impl<'a, W: Write> Serialize<LE, BEBitWriter<W>> for &'a TransitionState {
-	fn serialize(self, writer: &mut BEBitWriter<W>) -> Res<()> {
-		match self {
-			TransitionState::None => writer.write_bits(0, 2),
-			TransitionState::Arrive { last_custom_build_parts } => { writer.write_bits(1, 2)?; LEWrite::write(writer, last_custom_build_parts) },
-			TransitionState::Leave => writer.write_bits(2, 2),
-		}
-	}
+    fn serialize(self, writer: &mut BEBitWriter<W>) -> Res<()> {
+        match self {
+            TransitionState::None => writer.write_bits(0, 2),
+            TransitionState::Arrive {
+                last_custom_build_parts,
+            } => {
+                writer.write_bits(1, 2)?;
+                LEWrite::write(writer, last_custom_build_parts)
+            }
+            TransitionState::Leave => writer.write_bits(2, 2),
+        }
+    }
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct GmPvpInfo {
-	pub pvp_enabled: bool,
-	pub is_gm: bool,
-	pub gm_level: u8,
-	pub editor_enabled: bool,
-	pub editor_level: u8,
+    pub pvp_enabled: bool,
+    pub is_gm: bool,
+    pub gm_level: u8,
+    pub editor_enabled: bool,
+    pub editor_level: u8,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[repr(u32)]
 pub enum GameActivity {
-	None,
-	Quickbuilding,
-	ShootingGallery,
-	Racing,
-	Pinball,
-	PetTaming,
+    None,
+    Quickbuilding,
+    ShootingGallery,
+    Racing,
+    Pinball,
+    PetTaming,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
-#[trailing_padding=4] // country code, unused
+#[trailing_padding = 4] // country code, unused
 pub struct SocialInfo {
-	pub guild_id: ObjId,
-	pub guild_name: LuVarWString<u8>,
-	pub is_lego_club_member: bool,
+    pub guild_id: ObjId,
+    pub guild_name: LuVarWString<u8>,
+    pub is_lego_club_member: bool,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct CharacterConstruction {
-	pub claim_code_1: Option<u64>,
-	pub claim_code_2: Option<u64>,
-	pub claim_code_3: Option<u64>,
-	pub claim_code_4: Option<u64>,
-	// todo: type for each of the below
-	pub hair_color: u32,
-	pub hair_style: u32,
-	#[padding=4] // head style, unused
-	pub torso_color: u32,
-	pub legs_color: u32,
-	pub torso_decal: u32,
-	#[padding=4] // head color, unused
-	pub eyebrows_style: u32,
-	pub eyes_style: u32,
-	pub mouth_style: u32,
-	pub account_id: u64,
-	pub last_logout: u64,
-	pub prop_mod_last_display_time: u64,
-	pub u_score: u64,
-	pub is_free_trial: bool,
-	pub total_currency_collected: u64,
-	pub total_bricks_collected: u64,
-	pub total_smashables_smashed: u64,
-	pub total_quickbuilds_completed: u64,
-	pub total_enemies_smashed: u64,
-	pub total_rockets_used: u64,
-	pub total_missions_completed: u64,
-	pub total_pets_tamed: u64,
-	pub total_imagination_powerups_collected: u64,
-	pub total_life_powerups_collected: u64,
-	pub total_armor_powerups_collected: u64,
-	pub total_distance_traveled: u64,
-	pub times_smashed_count: u64,
-	pub total_damage_taken: u64,
-	pub total_damage_healed: u64,
-	pub total_armor_repaired: u64,
-	pub total_imagination_restored: u64,
-	pub total_imagination_used: u64,
-	pub total_distance_driven: u64,
-	pub total_time_airborne_in_a_race_car: u64,
-	pub total_racing_imagination_powerups_collected: u64,
-	pub total_racing_imagination_crates_smashed: u64,
-	pub total_racing_car_boosts_activated: u64,
-	pub total_racing_wrecks: u64,
-	pub total_racing_smashables_smashed: u64,
-	pub total_races_finished: u64,
-	pub total_first_place_race_finishes: u64,
-	pub transition_state: TransitionState,
-	pub gm_pvp_info: Option<GmPvpInfo>,
-	pub current_activity: Option<GameActivity>,
-	pub social_info: Option<SocialInfo>,
+    pub claim_code_1: Option<u64>,
+    pub claim_code_2: Option<u64>,
+    pub claim_code_3: Option<u64>,
+    pub claim_code_4: Option<u64>,
+    // todo: type for each of the below
+    pub hair_color: u32,
+    pub hair_style: u32,
+    #[padding = 4] // head style, unused
+    pub torso_color: u32,
+    pub legs_color: u32,
+    pub torso_decal: u32,
+    #[padding = 4] // head color, unused
+    pub eyebrows_style: u32,
+    pub eyes_style: u32,
+    pub mouth_style: u32,
+    pub account_id: u64,
+    pub last_logout: u64,
+    pub prop_mod_last_display_time: u64,
+    pub u_score: u64,
+    pub is_free_trial: bool,
+    pub total_currency_collected: u64,
+    pub total_bricks_collected: u64,
+    pub total_smashables_smashed: u64,
+    pub total_quickbuilds_completed: u64,
+    pub total_enemies_smashed: u64,
+    pub total_rockets_used: u64,
+    pub total_missions_completed: u64,
+    pub total_pets_tamed: u64,
+    pub total_imagination_powerups_collected: u64,
+    pub total_life_powerups_collected: u64,
+    pub total_armor_powerups_collected: u64,
+    pub total_distance_traveled: u64,
+    pub times_smashed_count: u64,
+    pub total_damage_taken: u64,
+    pub total_damage_healed: u64,
+    pub total_armor_repaired: u64,
+    pub total_imagination_restored: u64,
+    pub total_imagination_used: u64,
+    pub total_distance_driven: u64,
+    pub total_time_airborne_in_a_race_car: u64,
+    pub total_racing_imagination_powerups_collected: u64,
+    pub total_racing_imagination_crates_smashed: u64,
+    pub total_racing_car_boosts_activated: u64,
+    pub total_racing_wrecks: u64,
+    pub total_racing_smashables_smashed: u64,
+    pub total_races_finished: u64,
+    pub total_first_place_race_finishes: u64,
+    pub transition_state: TransitionState,
+    pub gm_pvp_info: Option<GmPvpInfo>,
+    pub current_activity: Option<GameActivity>,
+    pub social_info: Option<SocialInfo>,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct CharacterSerialization {
-	pub gm_pvp_info: Option<GmPvpInfo>,
-	pub current_activity: Option<GameActivity>,
-	pub social_info: Option<SocialInfo>,
+    pub gm_pvp_info: Option<GmPvpInfo>,
+    pub current_activity: Option<GameActivity>,
+    pub social_info: Option<SocialInfo>,
 }
 
 impl ComponentConstruction for CharacterConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 impl ComponentSerialization for CharacterSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct CharacterProtocol;
 
 impl ComponentProtocol for CharacterProtocol {
-	type Construction = CharacterConstruction;
-	type Serialization = CharacterSerialization;
+    type Construction = CharacterConstruction;
+    type Serialization = CharacterSerialization;
 }

--- a/src/raknet/client/replica/collectible.rs
+++ b/src/raknet/client/replica/collectible.rs
@@ -8,26 +8,26 @@ use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct CollectibleConstruction {
-	pub collectible_id: u16,
+    pub collectible_id: u16,
 }
 
 impl ComponentConstruction for CollectibleConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub type CollectibleSerialization = CollectibleConstruction;
 
 impl ComponentSerialization for CollectibleSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct CollectibleProtocol;
 
 impl ComponentProtocol for CollectibleProtocol {
-	type Construction = CollectibleConstruction;
-	type Serialization = CollectibleSerialization;
+    type Construction = CollectibleConstruction;
+    type Serialization = CollectibleSerialization;
 }

--- a/src/raknet/client/replica/controllable_physics.rs
+++ b/src/raknet/client/replica/controllable_physics.rs
@@ -1,106 +1,106 @@
-use std::io::{Result as Res};
+use std::io::Result as Res;
 
 use endio::{Deserialize, Serialize};
 use endio_bit::BEBitWriter;
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
-use crate::common::ObjId;
-use crate::world::{Vector3, Quaternion};
 use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
+use crate::common::ObjId;
+use crate::world::{Quaternion, Vector3};
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct JetpackInfo {
-	pub effect_id: i32, // todo: id
-	pub is_flying: bool,
-	pub bypass_checks: bool,
+    pub effect_id: i32, // todo: id
+    pub is_flying: bool,
+    pub bypass_checks: bool,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct StunImmunityInfo {
-	// todo: type
-	pub immune_to_stun_move: i32,
-	pub immune_to_stun_jump: i32,
-	pub immune_to_stun_turn: i32,
-	pub immune_to_stun_attack: i32,
-	pub immune_to_stun_use_item: i32,
-	pub immune_to_stun_equip: i32,
-	pub immune_to_stun_interact: i32,
+    // todo: type
+    pub immune_to_stun_move: i32,
+    pub immune_to_stun_jump: i32,
+    pub immune_to_stun_turn: i32,
+    pub immune_to_stun_attack: i32,
+    pub immune_to_stun_use_item: i32,
+    pub immune_to_stun_equip: i32,
+    pub immune_to_stun_interact: i32,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct CheatInfo {
-	pub gravity_scale: f32,
-	pub run_multiplier: f32,
+    pub gravity_scale: f32,
+    pub run_multiplier: f32,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct Unknown1 {
-	pub loot_pickup_radius: f32,
-	pub unknown_2: bool,
+    pub loot_pickup_radius: f32,
+    pub unknown_2: bool,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct Unknown2 {
-	pub unknown_1: Option<Unknown1>,
+    pub unknown_1: Option<Unknown1>,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct FrameStats {
-	pub position: Vector3,
-	pub rotation: Quaternion,
-	pub is_on_ground: bool,
-	pub is_on_rail: bool,
-	pub linear_velocity: Option<Vector3>,
-	pub angular_velocity: Option<Vector3>,
-	pub local_space_info: Option<LocalSpaceInfo>,
+    pub position: Vector3,
+    pub rotation: Quaternion,
+    pub is_on_ground: bool,
+    pub is_on_rail: bool,
+    pub linear_velocity: Option<Vector3>,
+    pub angular_velocity: Option<Vector3>,
+    pub local_space_info: Option<LocalSpaceInfo>,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct LocalSpaceInfo {
-	pub object_id: ObjId,
-	pub position: Vector3,
-	pub linear_velocity: Option<Vector3>,
+    pub object_id: ObjId,
+    pub position: Vector3,
+    pub linear_velocity: Option<Vector3>,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct ControllablePhysicsConstruction {
-	pub jetpack_info: Option<JetpackInfo>,
-	pub stun_immunity_info: Option<StunImmunityInfo>,
-	pub cheat_info: Option<CheatInfo>,
-	pub unknown_1: Option<Unknown1>,
-	pub unknown_2: Option<Unknown2>,
-	pub frame_stats: Option<FrameStats>,
+    pub jetpack_info: Option<JetpackInfo>,
+    pub stun_immunity_info: Option<StunImmunityInfo>,
+    pub cheat_info: Option<CheatInfo>,
+    pub unknown_1: Option<Unknown1>,
+    pub unknown_2: Option<Unknown2>,
+    pub frame_stats: Option<FrameStats>,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct FrameStatsTeleportInfo {
-	pub frame_stats: FrameStats,
-	pub is_teleporting: bool,
+    pub frame_stats: FrameStats,
+    pub is_teleporting: bool,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct ControllablePhysicsSerialization {
-	pub cheat_info: Option<CheatInfo>,
-	pub unknown_1: Option<Unknown1>,
-	pub unknown_2: Option<Unknown2>,
-	pub frame_stats_teleport_info: Option<FrameStatsTeleportInfo>,
+    pub cheat_info: Option<CheatInfo>,
+    pub unknown_1: Option<Unknown1>,
+    pub unknown_2: Option<Unknown2>,
+    pub frame_stats_teleport_info: Option<FrameStatsTeleportInfo>,
 }
 
 impl ComponentConstruction for ControllablePhysicsConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 impl ComponentSerialization for ControllablePhysicsSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct ControllablePhysicsProtocol;
 
 impl ComponentProtocol for ControllablePhysicsProtocol {
-	type Construction = ControllablePhysicsConstruction;
-	type Serialization = ControllablePhysicsSerialization;
+    type Construction = ControllablePhysicsConstruction;
+    type Serialization = ControllablePhysicsSerialization;
 }

--- a/src/raknet/client/replica/destroyable.rs
+++ b/src/raknet/client/replica/destroyable.rs
@@ -1,172 +1,172 @@
 use std::io::{Read, Result as Res, Write};
 
-use endio::{Deserialize, LE, LERead, LEWrite, Serialize};
+use endio::{Deserialize, LERead, LEWrite, Serialize, LE};
 use endio_bit::{BEBitReader, BEBitWriter};
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
-use crate::common::LVec;
 use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
+use crate::common::LVec;
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct StatusImmunityInfo {
-	pub immune_to_basic_attack: u32,
-	pub immune_to_damage_over_time: u32,
-	pub immune_to_knockback: u32,
-	pub immune_to_interrupt: u32,
-	pub immune_to_speed: u32,
-	pub immune_to_imagination_gain: u32,
-	pub immune_to_imagination_loss: u32,
-	pub immune_to_quickbuild_interrupt: u32,
-	pub immune_to_pull_to_point: u32,
+    pub immune_to_basic_attack: u32,
+    pub immune_to_damage_over_time: u32,
+    pub immune_to_knockback: u32,
+    pub immune_to_interrupt: u32,
+    pub immune_to_speed: u32,
+    pub immune_to_imagination_gain: u32,
+    pub immune_to_imagination_loss: u32,
+    pub immune_to_quickbuild_interrupt: u32,
+    pub immune_to_pull_to_point: u32,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct SmashableInfo {
-	pub is_module_assembly: bool,
-	pub explode_factor: Option<f32>,
+    pub is_module_assembly: bool,
+    pub explode_factor: Option<f32>,
 }
 
 // so close to being able to do serialization automatically...if not for the irregularity with `smashable_info`...
 #[derive(Debug, PartialEq)]
 pub struct StatsInfo {
-	pub cur_health: u32,
-	pub max_health: f32,
-	pub cur_armor: u32,
-	pub max_armor: f32,
-	pub cur_imag: u32,
-	pub max_imag: f32,
-	pub damage_absorption_points: u32,
-	pub immunity: bool,
-	pub is_gm_immune: bool,
-	pub is_shielded: bool,
-	pub actual_max_health: f32,
-	pub actual_max_armor: f32,
-	pub actual_max_imag: f32,
-	pub factions: LVec<u32, i32>,
-	pub is_dead: bool,
-	pub is_smashed: bool,
-	pub smashable_info: Option<SmashableInfo>,
+    pub cur_health: u32,
+    pub max_health: f32,
+    pub cur_armor: u32,
+    pub max_armor: f32,
+    pub cur_imag: u32,
+    pub max_imag: f32,
+    pub damage_absorption_points: u32,
+    pub immunity: bool,
+    pub is_gm_immune: bool,
+    pub is_shielded: bool,
+    pub actual_max_health: f32,
+    pub actual_max_armor: f32,
+    pub actual_max_imag: f32,
+    pub factions: LVec<u32, i32>,
+    pub is_dead: bool,
+    pub is_smashed: bool,
+    pub smashable_info: Option<SmashableInfo>,
 }
 
 impl<R: Read> Deserialize<LE, BEBitReader<R>> for StatsInfo {
-	fn deserialize(reader: &mut BEBitReader<R>) -> Res<Self> {
-		let cur_health = LERead::read(reader)?;
-		let max_health = LERead::read(reader)?;
-		let cur_armor  = LERead::read(reader)?;
-		let max_armor  = LERead::read(reader)?;
-		let cur_imag   = LERead::read(reader)?;
-		let max_imag   = LERead::read(reader)?;
-		let damage_absorption_points = LERead::read(reader)?;
-		let immunity     = reader.read_bit()?;
-		let is_gm_immune = reader.read_bit()?;
-		let is_shielded  = reader.read_bit()?;
-		let actual_max_health = LERead::read(reader)?;
-		let actual_max_armor  = LERead::read(reader)?;
-		let actual_max_imag   = LERead::read(reader)?;
-		let factions          = LERead::read(reader)?;
-		let is_smashable = reader.read_bit()?;
-		let is_dead      = reader.read_bit()?;
-		let is_smashed   = reader.read_bit()?;
-		let smashable_info = if is_smashable {
-			Some(LERead::read(reader)?)
-		} else {
-			None
-		};
-		Ok(Self {
-				cur_health,
-				max_health,
-				cur_armor,
-				max_armor,
-				cur_imag,
-				max_imag,
-				damage_absorption_points,
-				immunity,
-				is_gm_immune,
-				is_shielded,
-				actual_max_health,
-				actual_max_armor,
-				actual_max_imag,
-				factions,
-				is_dead,
-				is_smashed,
-				smashable_info,
-		})
-	}
+    fn deserialize(reader: &mut BEBitReader<R>) -> Res<Self> {
+        let cur_health = LERead::read(reader)?;
+        let max_health = LERead::read(reader)?;
+        let cur_armor = LERead::read(reader)?;
+        let max_armor = LERead::read(reader)?;
+        let cur_imag = LERead::read(reader)?;
+        let max_imag = LERead::read(reader)?;
+        let damage_absorption_points = LERead::read(reader)?;
+        let immunity = reader.read_bit()?;
+        let is_gm_immune = reader.read_bit()?;
+        let is_shielded = reader.read_bit()?;
+        let actual_max_health = LERead::read(reader)?;
+        let actual_max_armor = LERead::read(reader)?;
+        let actual_max_imag = LERead::read(reader)?;
+        let factions = LERead::read(reader)?;
+        let is_smashable = reader.read_bit()?;
+        let is_dead = reader.read_bit()?;
+        let is_smashed = reader.read_bit()?;
+        let smashable_info = if is_smashable {
+            Some(LERead::read(reader)?)
+        } else {
+            None
+        };
+        Ok(Self {
+            cur_health,
+            max_health,
+            cur_armor,
+            max_armor,
+            cur_imag,
+            max_imag,
+            damage_absorption_points,
+            immunity,
+            is_gm_immune,
+            is_shielded,
+            actual_max_health,
+            actual_max_armor,
+            actual_max_imag,
+            factions,
+            is_dead,
+            is_smashed,
+            smashable_info,
+        })
+    }
 }
 
 impl<'a, W: Write> Serialize<LE, BEBitWriter<W>> for &'a StatsInfo {
-	fn serialize(self, writer: &mut BEBitWriter<W>) -> Res<()> {
-		LEWrite::write(writer, self.cur_health)?;
-		LEWrite::write(writer, self.max_health)?;
-		LEWrite::write(writer, self.cur_armor)?;
-		LEWrite::write(writer, self.max_armor)?;
-		LEWrite::write(writer, self.cur_imag)?;
-		LEWrite::write(writer, self.max_imag)?;
-		LEWrite::write(writer, self.damage_absorption_points)?;
-		writer.write_bit(self.immunity)?;
-		writer.write_bit(self.is_gm_immune)?;
-		writer.write_bit(self.is_shielded)?;
-		LEWrite::write(writer, self.actual_max_health)?;
-		LEWrite::write(writer, self.actual_max_armor)?;
-		LEWrite::write(writer, self.actual_max_imag)?;
-		LEWrite::write(writer, &self.factions)?;
-		writer.write_bit(self.smashable_info.is_some())?;
-		writer.write_bit(self.is_dead)?;
-		writer.write_bit(self.is_smashed)?;
-		if let Some(x) = &self.smashable_info {
-			LEWrite::write(writer, x)?;
-		}
-		Ok(())
-	}
+    fn serialize(self, writer: &mut BEBitWriter<W>) -> Res<()> {
+        LEWrite::write(writer, self.cur_health)?;
+        LEWrite::write(writer, self.max_health)?;
+        LEWrite::write(writer, self.cur_armor)?;
+        LEWrite::write(writer, self.max_armor)?;
+        LEWrite::write(writer, self.cur_imag)?;
+        LEWrite::write(writer, self.max_imag)?;
+        LEWrite::write(writer, self.damage_absorption_points)?;
+        writer.write_bit(self.immunity)?;
+        writer.write_bit(self.is_gm_immune)?;
+        writer.write_bit(self.is_shielded)?;
+        LEWrite::write(writer, self.actual_max_health)?;
+        LEWrite::write(writer, self.actual_max_armor)?;
+        LEWrite::write(writer, self.actual_max_imag)?;
+        LEWrite::write(writer, &self.factions)?;
+        writer.write_bit(self.smashable_info.is_some())?;
+        writer.write_bit(self.is_dead)?;
+        writer.write_bit(self.is_smashed)?;
+        if let Some(x) = &self.smashable_info {
+            LEWrite::write(writer, x)?;
+        }
+        Ok(())
+    }
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct DestroyableConstruction {
-	pub status_immunity_info: Option<StatusImmunityInfo>,
-	pub stats_info: Option<StatsInfo>,
-	pub is_on_a_threat_list: Option<bool>,
+    pub status_immunity_info: Option<StatusImmunityInfo>,
+    pub stats_info: Option<StatsInfo>,
+    pub is_on_a_threat_list: Option<bool>,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct SerializationStatsInfo {
-	pub cur_health: u32,
-	pub max_health: f32,
-	pub cur_armor: u32,
-	pub max_armor: f32,
-	pub cur_imag: u32,
-	pub max_imag: f32,
-	pub damage_absorption_points: u32,
-	pub immunity: bool,
-	pub is_gm_immune: bool,
-	pub is_shielded: bool,
-	pub actual_max_health: f32,
-	pub actual_max_armor: f32,
-	pub actual_max_imag: f32,
-	pub factions: LVec<u32, i32>,
-	pub is_smashable: bool,
+    pub cur_health: u32,
+    pub max_health: f32,
+    pub cur_armor: u32,
+    pub max_armor: f32,
+    pub cur_imag: u32,
+    pub max_imag: f32,
+    pub damage_absorption_points: u32,
+    pub immunity: bool,
+    pub is_gm_immune: bool,
+    pub is_shielded: bool,
+    pub actual_max_health: f32,
+    pub actual_max_armor: f32,
+    pub actual_max_imag: f32,
+    pub factions: LVec<u32, i32>,
+    pub is_smashable: bool,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct DestroyableSerialization {
-	pub serialization_stats_info: Option<SerializationStatsInfo>,
-	pub is_on_a_threat_list: Option<bool>,
+    pub serialization_stats_info: Option<SerializationStatsInfo>,
+    pub is_on_a_threat_list: Option<bool>,
 }
 
 impl ComponentConstruction for DestroyableConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 impl ComponentSerialization for DestroyableSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct DestroyableProtocol;
 
 impl ComponentProtocol for DestroyableProtocol {
-	type Construction = DestroyableConstruction;
-	type Serialization = DestroyableSerialization;
+    type Construction = DestroyableConstruction;
+    type Serialization = DestroyableSerialization;
 }

--- a/src/raknet/client/replica/donation_vendor.rs
+++ b/src/raknet/client/replica/donation_vendor.rs
@@ -4,39 +4,39 @@ use endio::Serialize;
 use endio_bit::BEBitWriter;
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
-use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
 use super::vendor::VendorInfo;
+use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct DonationVendorInfo {
-	pub percent_complete: f32,
-	pub total_donated: u32,
-	pub total_remaining: u32,
+    pub percent_complete: f32,
+    pub total_donated: u32,
+    pub total_remaining: u32,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct DonationVendorConstruction {
-	pub vendor_info: Option<VendorInfo>,
-	pub donation_vendor_info: Option<DonationVendorInfo>,
+    pub vendor_info: Option<VendorInfo>,
+    pub donation_vendor_info: Option<DonationVendorInfo>,
 }
 
 impl ComponentConstruction for DonationVendorConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub type DonationVendorSerialization = DonationVendorConstruction;
 
 impl ComponentSerialization for DonationVendorSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct DonationVendorProtocol;
 
 impl ComponentProtocol for DonationVendorProtocol {
-	type Construction = DonationVendorConstruction;
-	type Serialization = DonationVendorSerialization;
+    type Construction = DonationVendorConstruction;
+    type Serialization = DonationVendorSerialization;
 }

--- a/src/raknet/client/replica/fx.rs
+++ b/src/raknet/client/replica/fx.rs
@@ -4,42 +4,41 @@ use endio::Serialize;
 use endio_bit::BEBitWriter;
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
-use crate::common::{LuVarString, LuVarWString, LVec, ObjId};
 use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
+use crate::common::{LVec, LuVarString, LuVarWString, ObjId};
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct EffectInfo {
-	pub effect_name: LuVarString<u8>,
-	pub effect_id: u32, // todo: type
-	pub effect_type: LuVarWString<u8>,
-	pub priority: f32,
-	pub secondary: ObjId,
+    pub effect_name: LuVarString<u8>,
+    pub effect_id: u32, // todo: type
+    pub effect_type: LuVarWString<u8>,
+    pub priority: f32,
+    pub secondary: ObjId,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct FxConstruction {
-	pub active_effects: LVec<u32, EffectInfo>,
+    pub active_effects: LVec<u32, EffectInfo>,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
-pub struct FxSerialization {
-}
+pub struct FxSerialization {}
 
 impl ComponentConstruction for FxConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 impl ComponentSerialization for FxSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct FxProtocol;
 
 impl ComponentProtocol for FxProtocol {
-	type Construction = FxConstruction;
-	type Serialization = FxSerialization;
+    type Construction = FxConstruction;
+    type Serialization = FxSerialization;
 }

--- a/src/raknet/client/replica/inventory.rs
+++ b/src/raknet/client/replica/inventory.rs
@@ -4,53 +4,53 @@ use endio::Serialize;
 use endio_bit::BEBitWriter;
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
-use crate::common::{LVec, ObjId};
-use crate::world::{LuNameValue, Lot, Quaternion, Vector3};
-use crate::world::gm::InventoryType;
 use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
+use crate::common::{LVec, ObjId};
+use crate::world::gm::InventoryType;
+use crate::world::{Lot, LuNameValue, Quaternion, Vector3};
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct EquippedItemInfo {
-	pub id: ObjId,
-	pub lot: Lot,
-	pub subkey: Option<ObjId>,
-	pub count: Option<u32>,
-	pub slot: Option<u16>,
-	pub inventory_type: Option<InventoryType>,
-	pub extra_info: Option<LuNameValue>,
-	pub is_bound: bool,
+    pub id: ObjId,
+    pub lot: Lot,
+    pub subkey: Option<ObjId>,
+    pub count: Option<u32>,
+    pub slot: Option<u16>,
+    pub inventory_type: Option<InventoryType>,
+    pub extra_info: Option<LuNameValue>,
+    pub is_bound: bool,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct EquippedModelTransform {
-	pub model_id: ObjId,
-	pub equip_position: Vector3,
-	pub equip_rotation: Quaternion,
+    pub model_id: ObjId,
+    pub equip_position: Vector3,
+    pub equip_rotation: Quaternion,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct InventoryConstruction {
-	pub equipped_items: Option<LVec<u32, EquippedItemInfo>>,
-	pub equipped_model_transforms: Option<LVec<u32, EquippedModelTransform>>,
+    pub equipped_items: Option<LVec<u32, EquippedItemInfo>>,
+    pub equipped_model_transforms: Option<LVec<u32, EquippedModelTransform>>,
 }
 
 impl ComponentConstruction for InventoryConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub type InventorySerialization = InventoryConstruction;
 
 impl ComponentSerialization for InventorySerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct InventoryProtocol;
 
 impl ComponentProtocol for InventoryProtocol {
-	type Construction = InventoryConstruction;
-	type Serialization = InventorySerialization;
+    type Construction = InventoryConstruction;
+    type Serialization = InventorySerialization;
 }

--- a/src/raknet/client/replica/item.rs
+++ b/src/raknet/client/replica/item.rs
@@ -4,46 +4,46 @@ use endio::{Deserialize, Serialize};
 use endio_bit::BEBitWriter;
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
-use crate::common::{LuVarWString, ObjId};
 use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
+use crate::common::{LuVarWString, ObjId};
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[repr(u32)]
 pub enum UgcModerationStatus {
-	NoStatus,
-	Approved,
-	Rejected,
+    NoStatus,
+    Approved,
+    Rejected,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct ItemInfo {
-	pub ug_id: ObjId,
-	pub ug_moderation_status: UgcModerationStatus,
-	pub ug_description: Option<LuVarWString<u32>>,
+    pub ug_id: ObjId,
+    pub ug_moderation_status: UgcModerationStatus,
+    pub ug_description: Option<LuVarWString<u32>>,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct ItemConstruction {
-	pub item_info: Option<ItemInfo>,
+    pub item_info: Option<ItemInfo>,
 }
 
 impl ComponentConstruction for ItemConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub type ItemSerialization = ItemConstruction;
 
 impl ComponentSerialization for ItemSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct ItemProtocol;
 
 impl ComponentProtocol for ItemProtocol {
-	type Construction = ItemConstruction;
-	type Serialization = ItemSerialization;
+    type Construction = ItemConstruction;
+    type Serialization = ItemSerialization;
 }

--- a/src/raknet/client/replica/level_progression.rs
+++ b/src/raknet/client/replica/level_progression.rs
@@ -8,26 +8,26 @@ use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct LevelProgressionConstruction {
-	pub current_level: Option<u32>,
+    pub current_level: Option<u32>,
 }
 
 impl ComponentConstruction for LevelProgressionConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub type LevelProgressionSerialization = LevelProgressionConstruction;
 
 impl ComponentSerialization for LevelProgressionSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct LevelProgressionProtocol;
 
 impl ComponentProtocol for LevelProgressionProtocol {
-	type Construction = LevelProgressionConstruction;
-	type Serialization = LevelProgressionSerialization;
+    type Construction = LevelProgressionConstruction;
+    type Serialization = LevelProgressionSerialization;
 }

--- a/src/raknet/client/replica/lup_exhibit.rs
+++ b/src/raknet/client/replica/lup_exhibit.rs
@@ -4,31 +4,31 @@ use endio::Serialize;
 use endio_bit::BEBitWriter;
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
-use crate::world::Lot;
 use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
+use crate::world::Lot;
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct LupExhibitConstruction {
-	pub exhibited_lot: Option<Lot>,
+    pub exhibited_lot: Option<Lot>,
 }
 
 impl ComponentConstruction for LupExhibitConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub type LupExhibitSerialization = LupExhibitConstruction;
 
 impl ComponentSerialization for LupExhibitSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct LupExhibitProtocol;
 
 impl ComponentProtocol for LupExhibitProtocol {
-	type Construction = LupExhibitConstruction;
-	type Serialization = LupExhibitSerialization;
+    type Construction = LupExhibitConstruction;
+    type Serialization = LupExhibitSerialization;
 }

--- a/src/raknet/client/replica/mod.rs
+++ b/src/raknet/client/replica/mod.rs
@@ -174,7 +174,7 @@ impl<R: Read + ReplicaContext> Deserialize<LE, R> for ReplicaConstruction {
     fn deserialize(reader: &mut R) -> Res<Self> {
         let mut bit_reader = BEBitReader::new(reader);
         let bit = bit_reader.read_bit()?;
-        assert_eq!(bit, true);
+        assert!(bit);
         let network_id = LERead::read(&mut bit_reader)?;
         let object_id = LERead::read(&mut bit_reader)?;
         let lot = LERead::read(&mut bit_reader)?;

--- a/src/raknet/client/replica/mod.rs
+++ b/src/raknet/client/replica/mod.rs
@@ -6,19 +6,19 @@ pub mod buff;
 pub mod character;
 pub mod collectible;
 pub mod controllable_physics;
-pub mod donation_vendor;
 pub mod destroyable;
+pub mod donation_vendor;
 pub mod fx;
 pub mod inventory;
 pub mod item;
 pub mod level_progression;
 pub mod lup_exhibit;
-pub mod mutable_model_behavior;
 pub mod module_assembly;
 pub mod moving_platform;
+pub mod mutable_model_behavior;
+pub mod pet;
 pub mod phantom_physics;
 pub mod player_forced_movement;
-pub mod pet;
 pub mod possessable;
 pub mod possession_control;
 pub mod quickbuild;
@@ -36,263 +36,287 @@ pub mod vendor;
 use std::fmt::Debug;
 use std::io::{Read, Result as Res, Write};
 
-use endio::{Deserialize, LE, LERead, LEWrite, Serialize};
+use endio::{Deserialize, LERead, LEWrite, Serialize, LE};
 use endio_bit::{BEBitReader, BEBitWriter};
 use lu_packets_derive::ReplicaSerde;
 
-use crate::common::{ObjId, LuVarWString, LVec};
+use crate::common::{LVec, LuVarWString, ObjId};
 use crate::world::{Lot, LuNameValue};
 
 trait ReplicaD<R: Read>: Sized {
-	fn deserialize(reader: &mut BEBitReader<R>) -> Res<Self>;
+    fn deserialize(reader: &mut BEBitReader<R>) -> Res<Self>;
 }
 
 trait ReplicaS<W: Write> {
-	fn serialize(self, writer: &mut BEBitWriter<W>) -> Res<()>;
+    fn serialize(self, writer: &mut BEBitWriter<W>) -> Res<()>;
 }
 
 impl<R: Read, T: Deserialize<LE, BEBitReader<R>>> ReplicaD<R> for T {
-	default fn deserialize(reader: &mut BEBitReader<R>) -> Res<Self> {
-		Deserialize::deserialize(reader)
-	}
+    default fn deserialize(reader: &mut BEBitReader<R>) -> Res<Self> {
+        Deserialize::deserialize(reader)
+    }
 }
 
-impl<'a, W: Write, T> ReplicaS<W> for &'a T where &'a T: Serialize<LE, BEBitWriter<W>> {
-	default fn serialize(self, writer: &mut BEBitWriter<W>) -> Res<()> {
-		Serialize::serialize(self, writer)
-	}
+impl<'a, W: Write, T> ReplicaS<W> for &'a T
+where
+    &'a T: Serialize<LE, BEBitWriter<W>>,
+{
+    default fn serialize(self, writer: &mut BEBitWriter<W>) -> Res<()> {
+        Serialize::serialize(self, writer)
+    }
 }
 
 impl<R: Read> ReplicaD<R> for bool {
-	fn deserialize(reader: &mut BEBitReader<R>) -> Res<Self> {
-		reader.read_bit()
-	}
+    fn deserialize(reader: &mut BEBitReader<R>) -> Res<Self> {
+        reader.read_bit()
+    }
 }
 
 impl<'a, W: Write> ReplicaS<W> for &'a bool {
-	fn serialize(self, writer: &mut BEBitWriter<W>) -> Res<()> {
-		writer.write_bit(*self)
-	}
+    fn serialize(self, writer: &mut BEBitWriter<W>) -> Res<()> {
+        writer.write_bit(*self)
+    }
 }
 
-impl<R: Read, T: ReplicaD<R>+Deserialize<LE, BEBitReader<R>>> ReplicaD<R> for Option<T> {
-	fn deserialize(reader: &mut BEBitReader<R>) -> Res<Self> {
-		let bit = reader.read_bit()?;
-		Ok(if !bit {
-			None
-		} else {
-			Some(ReplicaD::deserialize(reader)?)
-		})
-	}
+impl<R: Read, T: ReplicaD<R> + Deserialize<LE, BEBitReader<R>>> ReplicaD<R> for Option<T> {
+    fn deserialize(reader: &mut BEBitReader<R>) -> Res<Self> {
+        let bit = reader.read_bit()?;
+        Ok(if !bit {
+            None
+        } else {
+            Some(ReplicaD::deserialize(reader)?)
+        })
+    }
 }
 
-impl<W: Write, T> ReplicaS<W> for &Option<T> where for<'a> &'a T: ReplicaS<W>+Serialize<LE, BEBitWriter<W>> {
-	fn serialize(self, writer: &mut BEBitWriter<W>) -> Res<()> {
-		writer.write_bit(self.is_some())?;
-		if let Some(x) = self {
-			ReplicaS::serialize(x, writer)?;
-		}
-		Ok(())
-	}
+impl<W: Write, T> ReplicaS<W> for &Option<T>
+where
+    for<'a> &'a T: ReplicaS<W> + Serialize<LE, BEBitWriter<W>>,
+{
+    fn serialize(self, writer: &mut BEBitWriter<W>) -> Res<()> {
+        writer.write_bit(self.is_some())?;
+        if let Some(x) = self {
+            ReplicaS::serialize(x, writer)?;
+        }
+        Ok(())
+    }
 }
 
 pub trait ComponentConstruction: Debug {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()>;
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()>;
 }
 
 pub trait ComponentSerialization: Debug {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()>;
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()>;
 }
 
 pub trait ComponentProtocol {
-	type Construction: ComponentConstruction;
-	type Serialization: ComponentSerialization;
+    type Construction: ComponentConstruction;
+    type Serialization: ComponentSerialization;
 }
 
 pub trait ReplicaContext {
-	fn get_comp_constructions<R: Read>(&mut self, network_id: u16, lot: Lot, config: &Option<LuNameValue>) -> Vec<fn(&mut BEBitReader<R>) -> Res<Box<dyn ComponentConstruction>>>;
-	fn get_comp_serializations<R: Read>(&mut self, network_id: u16) -> Vec<fn(&mut BEBitReader<R>) -> Res<Box<dyn ComponentSerialization>>>;
+    fn get_comp_constructions<R: Read>(
+        &mut self,
+        network_id: u16,
+        lot: Lot,
+        config: &Option<LuNameValue>,
+    ) -> Vec<fn(&mut BEBitReader<R>) -> Res<Box<dyn ComponentConstruction>>>;
+    fn get_comp_serializations<R: Read>(
+        &mut self,
+        network_id: u16,
+    ) -> Vec<fn(&mut BEBitReader<R>) -> Res<Box<dyn ComponentSerialization>>>;
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct ParentInfo {
-	pub parent_id: ObjId,
-	pub update_position_with_parent: bool,
+    pub parent_id: ObjId,
+    pub update_position_with_parent: bool,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct ChildInfo {
-	pub child_ids: LVec<u16, ObjId>,
+    pub child_ids: LVec<u16, ObjId>,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct ParentChildInfo {
-	pub parent_info: Option<ParentInfo>,
-	pub child_info: Option<ChildInfo>,
+    pub parent_info: Option<ParentInfo>,
+    pub child_info: Option<ChildInfo>,
 }
 
 #[derive(Debug)]
 pub struct ReplicaConstruction {
-	pub network_id: u16,
-	pub object_id: ObjId,
-	pub lot: Lot,
-	pub name: LuVarWString<u8>,
-	pub time_since_created_on_server: u32,
-	pub config: Option<LuNameValue>,
-	pub is_trigger: bool,
-	pub spawner_id: Option<ObjId>,
-	pub spawner_node_id: Option<i32>,
-	pub scale: Option<f32>,
-	pub world_state: Option<u8>, // todo: type
-	pub gm_level: Option<u8>, // todo: type
-	pub parent_child_info: Option<ParentChildInfo>,
-	pub components: Vec<Box<dyn ComponentConstruction>>,
+    pub network_id: u16,
+    pub object_id: ObjId,
+    pub lot: Lot,
+    pub name: LuVarWString<u8>,
+    pub time_since_created_on_server: u32,
+    pub config: Option<LuNameValue>,
+    pub is_trigger: bool,
+    pub spawner_id: Option<ObjId>,
+    pub spawner_node_id: Option<i32>,
+    pub scale: Option<f32>,
+    pub world_state: Option<u8>, // todo: type
+    pub gm_level: Option<u8>,    // todo: type
+    pub parent_child_info: Option<ParentChildInfo>,
+    pub components: Vec<Box<dyn ComponentConstruction>>,
 }
 
 impl PartialEq<ReplicaConstruction> for ReplicaConstruction {
-	fn eq(&self, rhs: &ReplicaConstruction) -> bool {
-		// hacky but i don't know a better way
-		format!("{:?}", self) == format!("{:?}", rhs)
-	}
+    fn eq(&self, rhs: &ReplicaConstruction) -> bool {
+        // hacky but i don't know a better way
+        format!("{:?}", self) == format!("{:?}", rhs)
+    }
 }
 
-impl<R: Read+ReplicaContext> Deserialize<LE, R> for ReplicaConstruction {
-	fn deserialize(reader: &mut R) -> Res<Self> {
-		let mut bit_reader = BEBitReader::new(reader);
-		let bit = bit_reader.read_bit()?;
-		assert_eq!(bit, true);
-		let network_id = LERead::read(&mut bit_reader)?;
-		let object_id  = LERead::read(&mut bit_reader)?;
-		let lot        = LERead::read(&mut bit_reader)?;
-		let name       = LERead::read(&mut bit_reader)?;
-		let time_since_created_on_server = LERead::read(&mut bit_reader)?;
-		let config = ReplicaD::deserialize(&mut bit_reader)?;
-		let is_trigger = bit_reader.read_bit()?;
-		let spawner_id        = ReplicaD::deserialize(&mut bit_reader)?;
-		let spawner_node_id   = ReplicaD::deserialize(&mut bit_reader)?;
-		let scale             = ReplicaD::deserialize(&mut bit_reader)?;
-		let world_state       = ReplicaD::deserialize(&mut bit_reader)?;
-		let gm_level          = ReplicaD::deserialize(&mut bit_reader)?;
-		let parent_child_info = ReplicaD::deserialize(&mut bit_reader)?;
-		let mut components = vec![];
-		for new in unsafe {bit_reader.get_mut_unchecked()}.get_comp_constructions(network_id, lot, &config) {
-			components.push(new(&mut bit_reader)?);
-		}
+impl<R: Read + ReplicaContext> Deserialize<LE, R> for ReplicaConstruction {
+    fn deserialize(reader: &mut R) -> Res<Self> {
+        let mut bit_reader = BEBitReader::new(reader);
+        let bit = bit_reader.read_bit()?;
+        assert_eq!(bit, true);
+        let network_id = LERead::read(&mut bit_reader)?;
+        let object_id = LERead::read(&mut bit_reader)?;
+        let lot = LERead::read(&mut bit_reader)?;
+        let name = LERead::read(&mut bit_reader)?;
+        let time_since_created_on_server = LERead::read(&mut bit_reader)?;
+        let config = ReplicaD::deserialize(&mut bit_reader)?;
+        let is_trigger = bit_reader.read_bit()?;
+        let spawner_id = ReplicaD::deserialize(&mut bit_reader)?;
+        let spawner_node_id = ReplicaD::deserialize(&mut bit_reader)?;
+        let scale = ReplicaD::deserialize(&mut bit_reader)?;
+        let world_state = ReplicaD::deserialize(&mut bit_reader)?;
+        let gm_level = ReplicaD::deserialize(&mut bit_reader)?;
+        let parent_child_info = ReplicaD::deserialize(&mut bit_reader)?;
+        let mut components = vec![];
+        for new in unsafe { bit_reader.get_mut_unchecked() }
+            .get_comp_constructions(network_id, lot, &config)
+        {
+            components.push(new(&mut bit_reader)?);
+        }
 
-		Ok(Self {
-			network_id,
-			object_id,
-			lot,
-			name,
-			time_since_created_on_server,
-			config,
-			is_trigger,
-			spawner_id,
-			spawner_node_id,
-			scale,
-			world_state,
-			gm_level,
-			parent_child_info,
-			components,
-		})
-	}
+        Ok(Self {
+            network_id,
+            object_id,
+            lot,
+            name,
+            time_since_created_on_server,
+            config,
+            is_trigger,
+            spawner_id,
+            spawner_node_id,
+            scale,
+            world_state,
+            gm_level,
+            parent_child_info,
+            components,
+        })
+    }
 }
 
 impl<'a, W: Write> Serialize<LE, W> for &'a ReplicaConstruction {
-	fn serialize(self, writer: &mut W) -> Res<()> {
-		let mut bit_writer = BEBitWriter::new(vec![]);
-		bit_writer.write_bit(true)?;
-		LEWrite::write(&mut bit_writer, self.network_id)?;
-		LEWrite::write(&mut bit_writer, self.object_id)?;
-		LEWrite::write(&mut bit_writer, self.lot)?;
-		LEWrite::write(&mut bit_writer, &self.name)?;
-		LEWrite::write(&mut bit_writer, self.time_since_created_on_server)?;
-		ReplicaS::serialize(&self.config, &mut bit_writer)?;
-		bit_writer.write_bit(self.is_trigger)?;
-		ReplicaS::serialize(&self.spawner_id, &mut bit_writer)?;
-		ReplicaS::serialize(&self.spawner_node_id, &mut bit_writer)?;
-		ReplicaS::serialize(&self.scale, &mut bit_writer)?;
-		ReplicaS::serialize(&self.world_state, &mut bit_writer)?;
-		ReplicaS::serialize(&self.gm_level, &mut bit_writer)?;
-		ReplicaS::serialize(&self.parent_child_info, &mut bit_writer)?;
+    fn serialize(self, writer: &mut W) -> Res<()> {
+        let mut bit_writer = BEBitWriter::new(vec![]);
+        bit_writer.write_bit(true)?;
+        LEWrite::write(&mut bit_writer, self.network_id)?;
+        LEWrite::write(&mut bit_writer, self.object_id)?;
+        LEWrite::write(&mut bit_writer, self.lot)?;
+        LEWrite::write(&mut bit_writer, &self.name)?;
+        LEWrite::write(&mut bit_writer, self.time_since_created_on_server)?;
+        ReplicaS::serialize(&self.config, &mut bit_writer)?;
+        bit_writer.write_bit(self.is_trigger)?;
+        ReplicaS::serialize(&self.spawner_id, &mut bit_writer)?;
+        ReplicaS::serialize(&self.spawner_node_id, &mut bit_writer)?;
+        ReplicaS::serialize(&self.scale, &mut bit_writer)?;
+        ReplicaS::serialize(&self.world_state, &mut bit_writer)?;
+        ReplicaS::serialize(&self.gm_level, &mut bit_writer)?;
+        ReplicaS::serialize(&self.parent_child_info, &mut bit_writer)?;
 
-		for comp in &self.components {
-			comp.ser(&mut bit_writer)?;
-		}
-		bit_writer.flush()?;
-		LEWrite::write(writer, bit_writer.get_ref())?;
-		Ok(())
-	}
+        for comp in &self.components {
+            comp.ser(&mut bit_writer)?;
+        }
+        bit_writer.flush()?;
+        LEWrite::write(writer, bit_writer.get_ref())?;
+        Ok(())
+    }
 }
 
 #[derive(Debug)]
 pub struct ReplicaSerialization {
-	pub network_id: u16,
-	pub parent_child_info: Option<ParentChildInfo>,
-	pub components: Vec<Box<dyn ComponentSerialization>>,
+    pub network_id: u16,
+    pub parent_child_info: Option<ParentChildInfo>,
+    pub components: Vec<Box<dyn ComponentSerialization>>,
 }
 
 impl PartialEq<ReplicaSerialization> for ReplicaSerialization {
-	fn eq(&self, rhs: &ReplicaSerialization) -> bool {
-		// hacky but i don't know a better way
-		format!("{:?}", self) == format!("{:?}", rhs)
-	}
+    fn eq(&self, rhs: &ReplicaSerialization) -> bool {
+        // hacky but i don't know a better way
+        format!("{:?}", self) == format!("{:?}", rhs)
+    }
 }
 
-impl<R: Read+ReplicaContext> Deserialize<LE, R> for ReplicaSerialization {
-	fn deserialize(reader: &mut R) -> Res<Self> {
-		let network_id = LERead::read(reader)?;
-		let comp_desers = reader.get_comp_serializations(network_id);
-		let mut bit_reader = BEBitReader::new(reader);
-		let parent_child_info = ReplicaD::deserialize(&mut bit_reader)?;
-		let mut components = vec![];
-		for new in comp_desers {
-			components.push(new(&mut bit_reader)?);
-		}
+impl<R: Read + ReplicaContext> Deserialize<LE, R> for ReplicaSerialization {
+    fn deserialize(reader: &mut R) -> Res<Self> {
+        let network_id = LERead::read(reader)?;
+        let comp_desers = reader.get_comp_serializations(network_id);
+        let mut bit_reader = BEBitReader::new(reader);
+        let parent_child_info = ReplicaD::deserialize(&mut bit_reader)?;
+        let mut components = vec![];
+        for new in comp_desers {
+            components.push(new(&mut bit_reader)?);
+        }
 
-		Ok(Self {
-			network_id,
-			parent_child_info,
-			components,
-		})
-	}
+        Ok(Self {
+            network_id,
+            parent_child_info,
+            components,
+        })
+    }
 }
 
 impl<'a, W: Write> Serialize<LE, W> for &'a ReplicaSerialization {
-	fn serialize(self, writer: &mut W) -> Res<()> {
-		LEWrite::write(writer, self.network_id)?;
-		let mut bit_writer = BEBitWriter::new(vec![]);
-		ReplicaS::serialize(&self.parent_child_info, &mut bit_writer)?;
+    fn serialize(self, writer: &mut W) -> Res<()> {
+        LEWrite::write(writer, self.network_id)?;
+        let mut bit_writer = BEBitWriter::new(vec![]);
+        ReplicaS::serialize(&self.parent_child_info, &mut bit_writer)?;
 
-		for comp in &self.components {
-			comp.ser(&mut bit_writer)?;
-		}
-		bit_writer.flush()?;
-		LEWrite::write(writer, bit_writer.get_ref())?;
-		Ok(())
-	}
+        for comp in &self.components {
+            comp.ser(&mut bit_writer)?;
+        }
+        bit_writer.flush()?;
+        LEWrite::write(writer, bit_writer.get_ref())?;
+        Ok(())
+    }
 }
 
 #[cfg(test)]
 #[derive(Debug)]
 pub(super) struct DummyContext<'a> {
-	pub(super) inner: &'a mut &'a[u8],
+    pub(super) inner: &'a mut &'a [u8],
 }
 
 #[cfg(test)]
 impl Read for DummyContext<'_> {
-	fn read(&mut self, buf: &mut [u8]) -> Res<usize> {
-		Read::read(self.inner, buf)
-	}
+    fn read(&mut self, buf: &mut [u8]) -> Res<usize> {
+        Read::read(self.inner, buf)
+    }
 }
 
 #[cfg(test)]
 impl ReplicaContext for DummyContext<'_> {
-	fn get_comp_constructions<R: Read>(&mut self, _network_id: u16, _lot: Lot, _config: &Option<LuNameValue>) -> Vec<fn(&mut BEBitReader<R>) -> Res<Box<dyn ComponentConstruction>>> {
-		vec![]
-	}
+    fn get_comp_constructions<R: Read>(
+        &mut self,
+        _network_id: u16,
+        _lot: Lot,
+        _config: &Option<LuNameValue>,
+    ) -> Vec<fn(&mut BEBitReader<R>) -> Res<Box<dyn ComponentConstruction>>> {
+        vec![]
+    }
 
-	fn get_comp_serializations<R: Read>(&mut self, _network_id: u16) -> Vec<fn(&mut BEBitReader<R>) -> Res<Box<dyn ComponentSerialization>>> {
-		vec![]
-	}
+    fn get_comp_serializations<R: Read>(
+        &mut self,
+        _network_id: u16,
+    ) -> Vec<fn(&mut BEBitReader<R>) -> Res<Box<dyn ComponentSerialization>>> {
+        vec![]
+    }
 }

--- a/src/raknet/client/replica/module_assembly.rs
+++ b/src/raknet/client/replica/module_assembly.rs
@@ -4,38 +4,38 @@ use endio::Serialize;
 use endio_bit::BEBitWriter;
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
-use crate::common::{LuVarWString, ObjId};
 use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
+use crate::common::{LuVarWString, ObjId};
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct ModuleAssemblyInfo {
-	pub assembly_id: Option<ObjId>,
-	pub use_optional_parts: bool,
-	pub blob: LuVarWString<u16>,
+    pub assembly_id: Option<ObjId>,
+    pub use_optional_parts: bool,
+    pub blob: LuVarWString<u16>,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct ModuleAssemblyConstruction {
-	pub module_assembly_info: Option<ModuleAssemblyInfo>,
+    pub module_assembly_info: Option<ModuleAssemblyInfo>,
 }
 
 impl ComponentConstruction for ModuleAssemblyConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub type ModuleAssemblySerialization = ModuleAssemblyConstruction;
 
 impl ComponentSerialization for ModuleAssemblySerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct ModuleAssemblyProtocol;
 
 impl ComponentProtocol for ModuleAssemblyProtocol {
-	type Construction = ModuleAssemblyConstruction;
-	type Serialization = ModuleAssemblySerialization;
+    type Construction = ModuleAssemblyConstruction;
+    type Serialization = ModuleAssemblySerialization;
 }

--- a/src/raknet/client/replica/moving_platform.rs
+++ b/src/raknet/client/replica/moving_platform.rs
@@ -1,130 +1,133 @@
 use std::io::{Read, Result as Res, Write};
 
-use endio::{Deserialize, LE, Serialize};
+use endio::{Deserialize, Serialize, LE};
 use endio_bit::{BEBitReader, BEBitWriter};
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
+use super::simple_physics::PositionRotationInfo;
+use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization, ReplicaD};
 use crate::common::LuVarWString;
 use crate::world::Vector3;
-use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization, ReplicaD};
-use super::simple_physics::PositionRotationInfo;
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct PlatformMoverInfo {
-	/// todo: bitfield
-	pub state: u32,
-	/// todo: u32 with special case for -1
-	pub desired_waypoint_index: i32,
-	pub stop_at_desired_waypoint: bool,
-	pub is_in_reverse: bool,
-	pub percent_to_next_waypoint: f32,
-	/// not completely sure what this position is
-	pub position: Vector3,
-	pub current_waypoint_index: u32,
-	pub next_waypoint_index: u32,
-	pub idle_time_elapsed: f32,
-	pub move_time_elapsed: f32,
+    /// todo: bitfield
+    pub state: u32,
+    /// todo: u32 with special case for -1
+    pub desired_waypoint_index: i32,
+    pub stop_at_desired_waypoint: bool,
+    pub is_in_reverse: bool,
+    pub percent_to_next_waypoint: f32,
+    /// not completely sure what this position is
+    pub position: Vector3,
+    pub current_waypoint_index: u32,
+    pub next_waypoint_index: u32,
+    pub idle_time_elapsed: f32,
+    pub move_time_elapsed: f32,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct PlatformSimpleMoverExtraInfo {
-	/// todo: bitfield
-	pub state: u32,
-	pub current_waypoint_index: u32,
-	pub is_in_reverse: bool,
+    /// todo: bitfield
+    pub state: u32,
+    pub current_waypoint_index: u32,
+    pub is_in_reverse: bool,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct PlatformSimpleMoverInfo {
-	pub start_point_position_rotation_info: Option<Option<PositionRotationInfo>>,
-	pub extra_info: Option<PlatformSimpleMoverExtraInfo>,
+    pub start_point_position_rotation_info: Option<Option<PositionRotationInfo>>,
+    pub extra_info: Option<PlatformSimpleMoverExtraInfo>,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 #[repr(u32)]
 pub enum PlatformSubcomponentInfo {
-	Mover(Option<PlatformMoverInfo>) = 4,
-	SimpleMover(PlatformSimpleMoverInfo) = 5,
+    Mover(Option<PlatformMoverInfo>) = 4,
+    SimpleMover(PlatformSimpleMoverInfo) = 5,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct PlatformPathInfo {
-	pub path_name: LuVarWString<u16>,
-	pub starting_waypoint: u32,
-	pub is_in_reverse: bool,
+    pub path_name: LuVarWString<u16>,
+    pub starting_waypoint: u32,
+    pub is_in_reverse: bool,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq)]
 pub struct MovingPlatformConstruction {
-	pub path_info: Option<PlatformPathInfo>,
-	pub subcomponent_infos: Option<Vec<PlatformSubcomponentInfo>>,
+    pub path_info: Option<PlatformPathInfo>,
+    pub subcomponent_infos: Option<Vec<PlatformSubcomponentInfo>>,
 }
 
 impl<R: Read> Deserialize<LE, BEBitReader<R>> for MovingPlatformConstruction {
-	fn deserialize(reader: &mut BEBitReader<R>) -> Res<Self> {
-		let has_subcomponent_infos = reader.read_bit()?;
-		let flag = reader.read_bit()?;
-		let path_info = if flag {
-			ReplicaD::deserialize(reader)?
-		} else {
-			None
-		};
-		let subcomponent_infos = if has_subcomponent_infos {
-			let mut infos = vec![];
-			while reader.read_bit()? {
-				let subcomp = ReplicaD::deserialize(reader)?;
-				infos.push(subcomp);
-			}
-			Some(infos)
-		} else {
-			None
-		};
-		Ok(Self { path_info, subcomponent_infos })
-	}
+    fn deserialize(reader: &mut BEBitReader<R>) -> Res<Self> {
+        let has_subcomponent_infos = reader.read_bit()?;
+        let flag = reader.read_bit()?;
+        let path_info = if flag {
+            ReplicaD::deserialize(reader)?
+        } else {
+            None
+        };
+        let subcomponent_infos = if has_subcomponent_infos {
+            let mut infos = vec![];
+            while reader.read_bit()? {
+                let subcomp = ReplicaD::deserialize(reader)?;
+                infos.push(subcomp);
+            }
+            Some(infos)
+        } else {
+            None
+        };
+        Ok(Self {
+            path_info,
+            subcomponent_infos,
+        })
+    }
 }
 
 impl<'a, W: Write> Serialize<LE, BEBitWriter<W>> for &'a MovingPlatformConstruction {
-	fn serialize(self, writer: &mut BEBitWriter<W>) -> Res<()> {
-		writer.write_bit(self.subcomponent_infos.is_some())?;
-		if let Some(path_info) = &self.path_info {
-			if !path_info.path_name.is_empty() {
-				writer.write_bit(true)?;
-				writer.write_bit(true)?;
-				crate::raknet::client::replica::ReplicaS::serialize(path_info, writer)?;
-			} else {
-				writer.write_bit(false)?;
-			}
-		} else {
-			writer.write_bit(false)?;
-		}
-		if let Some(subcomponent_infos) = &self.subcomponent_infos {
-			for sci in subcomponent_infos {
-				writer.write_bit(true)?;
-				crate::raknet::client::replica::ReplicaS::serialize(sci, writer)?;
-			}
-			writer.write_bit(false)?;
-		}
-		Ok(())
-	}
+    fn serialize(self, writer: &mut BEBitWriter<W>) -> Res<()> {
+        writer.write_bit(self.subcomponent_infos.is_some())?;
+        if let Some(path_info) = &self.path_info {
+            if !path_info.path_name.is_empty() {
+                writer.write_bit(true)?;
+                writer.write_bit(true)?;
+                crate::raknet::client::replica::ReplicaS::serialize(path_info, writer)?;
+            } else {
+                writer.write_bit(false)?;
+            }
+        } else {
+            writer.write_bit(false)?;
+        }
+        if let Some(subcomponent_infos) = &self.subcomponent_infos {
+            for sci in subcomponent_infos {
+                writer.write_bit(true)?;
+                crate::raknet::client::replica::ReplicaS::serialize(sci, writer)?;
+            }
+            writer.write_bit(false)?;
+        }
+        Ok(())
+    }
 }
 
 impl ComponentConstruction for MovingPlatformConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub type MovingPlatformSerialization = MovingPlatformConstruction;
 
 impl ComponentSerialization for MovingPlatformSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct MovingPlatformProtocol;
 
 impl ComponentProtocol for MovingPlatformProtocol {
-	type Construction = MovingPlatformConstruction;
-	type Serialization = MovingPlatformSerialization;
+    type Construction = MovingPlatformConstruction;
+    type Serialization = MovingPlatformSerialization;
 }

--- a/src/raknet/client/replica/mutable_model_behavior.rs
+++ b/src/raknet/client/replica/mutable_model_behavior.rs
@@ -4,75 +4,75 @@ use endio::{Deserialize, Serialize};
 use endio_bit::BEBitWriter;
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
-use crate::common::ObjId;
-use crate::world::{Vector3, Quaternion};
 use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
+use crate::common::ObjId;
+use crate::world::{Quaternion, Vector3};
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[repr(i32)]
 pub enum PhysicsBehaviorType {
-	/// todo: option
-	Invalid = -1,
-	Ground,
-	Flying,
-	Standard,
-	Dynamic,
+    /// todo: option
+    Invalid = -1,
+    Ground,
+    Flying,
+    Standard,
+    Dynamic,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct ModelBehaviorInfo {
-	pub is_pickable: bool,
-	pub physics_behavior_type: PhysicsBehaviorType,
-	pub original_position: Vector3,
-	pub original_rotation: Quaternion,
+    pub is_pickable: bool,
+    pub physics_behavior_type: PhysicsBehaviorType,
+    pub original_position: Vector3,
+    pub original_rotation: Quaternion,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct ModelEditingInfo {
-	pub old_object_id: ObjId,
-	pub player_editing_model: ObjId,
+    pub old_object_id: ObjId,
+    pub player_editing_model: ObjId,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct MutableModelBehaviorConstructionInfo {
-	pub behavior_count: u32,
-	pub is_paused: bool,
-	pub model_editing_info: Option<ModelEditingInfo>,
+    pub behavior_count: u32,
+    pub is_paused: bool,
+    pub model_editing_info: Option<ModelEditingInfo>,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct MutableModelBehaviorConstruction {
-	pub model_behavior_info: Option<ModelBehaviorInfo>,
-	pub mutable_model_behavior_construction_info: Option<MutableModelBehaviorConstructionInfo>,
+    pub model_behavior_info: Option<ModelBehaviorInfo>,
+    pub mutable_model_behavior_construction_info: Option<MutableModelBehaviorConstructionInfo>,
 }
 
 impl ComponentConstruction for MutableModelBehaviorConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct MutableModelBehaviorSerializationInfo {
-	pub behavior_count: u32,
-	pub is_paused: bool,
+    pub behavior_count: u32,
+    pub is_paused: bool,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct MutableModelBehaviorSerialization {
-	pub model_behavior_info: Option<ModelBehaviorInfo>,
-	pub mutable_model_behavior_serialization_info: Option<MutableModelBehaviorSerializationInfo>,
+    pub model_behavior_info: Option<ModelBehaviorInfo>,
+    pub mutable_model_behavior_serialization_info: Option<MutableModelBehaviorSerializationInfo>,
 }
 
 impl ComponentSerialization for MutableModelBehaviorSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct MutableModelBehaviorProtocol;
 
 impl ComponentProtocol for MutableModelBehaviorProtocol {
-	type Construction = MutableModelBehaviorConstruction;
-	type Serialization = MutableModelBehaviorSerialization;
+    type Construction = MutableModelBehaviorConstruction;
+    type Serialization = MutableModelBehaviorSerialization;
 }

--- a/src/raknet/client/replica/pet.rs
+++ b/src/raknet/client/replica/pet.rs
@@ -4,70 +4,70 @@ use endio::{Deserialize, Serialize};
 use endio_bit::BEBitWriter;
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
+use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
 use crate::common::{LuVarWString, ObjId};
 use crate::world::gm::client::{PetAbilityType, PetModerationStatus};
-use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[repr(u8)]
 pub enum PossessionType {
-	NoPossession,
-	AttachedVisible,
-	NotAttachedVisible,
-	NotAttachedNotVisible,
+    NoPossession,
+    AttachedVisible,
+    NotAttachedVisible,
+    NotAttachedNotVisible,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct TamedPetInfo {
-	pub pet_name_moderation_status: PetModerationStatus,
-	pub pet_name: LuVarWString<u8>,
-	pub owner_name: LuVarWString<u8>,
+    pub pet_name_moderation_status: PetModerationStatus,
+    pub pet_name: LuVarWString<u8>,
+    pub owner_name: LuVarWString<u8>,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct PetConstructionInfo {
-	/// todo: bitflag
-	pub pet_state: u32,
-	pub ability_in_use: PetAbilityType,
-	pub interaction_id: Option<ObjId>,
-	pub owner_id: Option<ObjId>,
-	pub tamed_pet_info: Option<TamedPetInfo>,
+    /// todo: bitflag
+    pub pet_state: u32,
+    pub ability_in_use: PetAbilityType,
+    pub interaction_id: Option<ObjId>,
+    pub owner_id: Option<ObjId>,
+    pub tamed_pet_info: Option<TamedPetInfo>,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct PetConstruction {
-	pub pet_construction_info: Option<PetConstructionInfo>,
+    pub pet_construction_info: Option<PetConstructionInfo>,
 }
 
 impl ComponentConstruction for PetConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct PetSerializationInfo {
-	/// todo: bitflag
-	pub pet_state: u32,
-	pub ability_in_use: PetAbilityType,
-	pub interaction_id: Option<ObjId>,
-	pub owner_id: Option<ObjId>,
+    /// todo: bitflag
+    pub pet_state: u32,
+    pub ability_in_use: PetAbilityType,
+    pub interaction_id: Option<ObjId>,
+    pub owner_id: Option<ObjId>,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct PetSerialization {
-	pub pet_serialization_info: Option<PetSerializationInfo>,
+    pub pet_serialization_info: Option<PetSerializationInfo>,
 }
 
 impl ComponentSerialization for PetSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct PetProtocol;
 
 impl ComponentProtocol for PetProtocol {
-	type Construction = PetConstruction;
-	type Serialization = PetSerialization;
+    type Construction = PetConstruction;
+    type Serialization = PetSerialization;
 }

--- a/src/raknet/client/replica/phantom_physics.rs
+++ b/src/raknet/client/replica/phantom_physics.rs
@@ -1,65 +1,65 @@
-use std::io::{Result as Res};
+use std::io::Result as Res;
 
 use endio::{Deserialize, Serialize};
 use endio_bit::BEBitWriter;
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
-use crate::world::Vector3;
-use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
 use super::simple_physics::PositionRotationInfo;
+use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
+use crate::world::Vector3;
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[repr(u32)]
 pub enum PhysicsEffectType {
-	Push,
-	Attract,
-	Repulse,
-	GravityScale,
-	Friction,
+    Push,
+    Attract,
+    Repulse,
+    GravityScale,
+    Friction,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct DistanceInfo {
-	pub min_distance: f32,
-	pub max_distance: f32,
+    pub min_distance: f32,
+    pub max_distance: f32,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct PhysicsEffectInfo {
-	pub effect_type: PhysicsEffectType,
-	pub amount: f32,
-	pub distance_info: Option<DistanceInfo>,
-	pub impulse_velocity: Option<Vector3>,
+    pub effect_type: PhysicsEffectType,
+    pub amount: f32,
+    pub distance_info: Option<DistanceInfo>,
+    pub impulse_velocity: Option<Vector3>,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct ActivePhysicsEffectInfo {
-	pub active_physics_effect: Option<PhysicsEffectInfo>,
+    pub active_physics_effect: Option<PhysicsEffectInfo>,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct PhantomPhysicsConstruction {
-	pub position_rotation_info: Option<PositionRotationInfo>,
-	pub active_physics_effect_info: Option<ActivePhysicsEffectInfo>,
+    pub position_rotation_info: Option<PositionRotationInfo>,
+    pub active_physics_effect_info: Option<ActivePhysicsEffectInfo>,
 }
 
 impl ComponentConstruction for PhantomPhysicsConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub type PhantomPhysicsSerialization = PhantomPhysicsConstruction;
 
 impl ComponentSerialization for PhantomPhysicsSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct PhantomPhysicsProtocol;
 
 impl ComponentProtocol for PhantomPhysicsProtocol {
-	type Construction = PhantomPhysicsConstruction;
-	type Serialization = PhantomPhysicsSerialization;
+    type Construction = PhantomPhysicsConstruction;
+    type Serialization = PhantomPhysicsSerialization;
 }

--- a/src/raknet/client/replica/player_forced_movement.rs
+++ b/src/raknet/client/replica/player_forced_movement.rs
@@ -8,32 +8,32 @@ use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct ForcedMovementInfo {
-	pub player_on_rail: bool,
-	pub show_billboard: bool,
+    pub player_on_rail: bool,
+    pub show_billboard: bool,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct PlayerForcedMovementConstruction {
-	pub forced_movement_info: Option<ForcedMovementInfo>,
+    pub forced_movement_info: Option<ForcedMovementInfo>,
 }
 
 impl ComponentConstruction for PlayerForcedMovementConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub type PlayerForcedMovementSerialization = PlayerForcedMovementConstruction;
 
 impl ComponentSerialization for PlayerForcedMovementSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct PlayerForcedMovementProtocol;
 
 impl ComponentProtocol for PlayerForcedMovementProtocol {
-	type Construction = PlayerForcedMovementConstruction;
-	type Serialization = PlayerForcedMovementSerialization;
+    type Construction = PlayerForcedMovementConstruction;
+    type Serialization = PlayerForcedMovementSerialization;
 }

--- a/src/raknet/client/replica/possessable.rs
+++ b/src/raknet/client/replica/possessable.rs
@@ -4,38 +4,38 @@ use endio::Serialize;
 use endio_bit::BEBitWriter;
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
-use crate::common::ObjId;
 use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
+use crate::common::ObjId;
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct PossessableInfo {
-	pub possessor_id: Option<ObjId>,
-	pub animation_flag: Option<u32>,
-	pub immediate_depossess: bool,
+    pub possessor_id: Option<ObjId>,
+    pub animation_flag: Option<u32>,
+    pub immediate_depossess: bool,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct PossessableConstruction {
-	pub possessable_info: Option<PossessableInfo>,
+    pub possessable_info: Option<PossessableInfo>,
 }
 
 impl ComponentConstruction for PossessableConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub type PossessableSerialization = PossessableConstruction;
 
 impl ComponentSerialization for PossessableSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct PossessableProtocol;
 
 impl ComponentProtocol for PossessableProtocol {
-	type Construction = PossessableConstruction;
-	type Serialization = PossessableSerialization;
+    type Construction = PossessableConstruction;
+    type Serialization = PossessableSerialization;
 }

--- a/src/raknet/client/replica/possession_control.rs
+++ b/src/raknet/client/replica/possession_control.rs
@@ -4,46 +4,46 @@ use endio::{Deserialize, Serialize};
 use endio_bit::BEBitWriter;
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
-use crate::common::ObjId;
 use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
+use crate::common::ObjId;
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[repr(u8)]
 pub enum PossessionType {
-	NoPossession,
-	AttachedVisible,
-	NotAttachedVisible,
-	NotAttachedNotVisible,
+    NoPossession,
+    AttachedVisible,
+    NotAttachedVisible,
+    NotAttachedNotVisible,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct PossessionInfo {
-	pub possessed_id: Option<ObjId>,
-	pub possession_type: PossessionType,
+    pub possessed_id: Option<ObjId>,
+    pub possession_type: PossessionType,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct PossessionControlConstruction {
-	pub possession_info: Option<PossessionInfo>,
+    pub possession_info: Option<PossessionInfo>,
 }
 
 impl ComponentConstruction for PossessionControlConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub type PossessionControlSerialization = PossessionControlConstruction;
 
 impl ComponentSerialization for PossessionControlSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct PossessionControlProtocol;
 
 impl ComponentProtocol for PossessionControlProtocol {
-	type Construction = PossessionControlConstruction;
-	type Serialization = PossessionControlSerialization;
+    type Construction = PossessionControlConstruction;
+    type Serialization = PossessionControlSerialization;
 }

--- a/src/raknet/client/replica/quickbuild.rs
+++ b/src/raknet/client/replica/quickbuild.rs
@@ -4,60 +4,60 @@ use endio::Serialize;
 use endio_bit::BEBitWriter;
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
-use crate::common::LVec;
-use crate::world::Vector3;
-use crate::world::gm::client::RebuildChallengeState;
-use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
 use super::scripted_activity::ActivityUserInfo;
+use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
+use crate::common::LVec;
+use crate::world::gm::client::RebuildChallengeState;
+use crate::world::Vector3;
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct QuickbuildConstructionInfo {
-	pub current_state: RebuildChallengeState,
-	pub show_reset_effect: bool,
-	pub has_activator: bool,
-	pub duration_timer: f32,
-	pub total_incomplete_time: f32,
-	pub unknown: Option<u32>,
-	pub activator_position: Vector3,
-	pub reposition_player: bool,
+    pub current_state: RebuildChallengeState,
+    pub show_reset_effect: bool,
+    pub has_activator: bool,
+    pub duration_timer: f32,
+    pub total_incomplete_time: f32,
+    pub unknown: Option<u32>,
+    pub activator_position: Vector3,
+    pub reposition_player: bool,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct QuickbuildConstruction {
-	pub activity_user_infos: Option<LVec<u32, ActivityUserInfo>>,
-	pub quickbuild_construction_info: Option<QuickbuildConstructionInfo>,
+    pub activity_user_infos: Option<LVec<u32, ActivityUserInfo>>,
+    pub quickbuild_construction_info: Option<QuickbuildConstructionInfo>,
 }
 
 impl ComponentConstruction for QuickbuildConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct QuickbuildSerializationInfo {
-	pub current_state: RebuildChallengeState,
-	pub show_reset_effect: bool,
-	pub has_activator: bool,
-	pub duration_timer: f32,
-	pub total_incomplete_time: f32,
+    pub current_state: RebuildChallengeState,
+    pub show_reset_effect: bool,
+    pub has_activator: bool,
+    pub duration_timer: f32,
+    pub total_incomplete_time: f32,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct QuickbuildSerialization {
-	pub activity_user_infos: Option<LVec<u32, ActivityUserInfo>>,
-	pub quickbuild_serialization_info: Option<QuickbuildSerializationInfo>,
+    pub activity_user_infos: Option<LVec<u32, ActivityUserInfo>>,
+    pub quickbuild_serialization_info: Option<QuickbuildSerializationInfo>,
 }
 
 impl ComponentSerialization for QuickbuildSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct QuickbuildProtocol;
 
 impl ComponentProtocol for QuickbuildProtocol {
-	type Construction = QuickbuildConstruction;
-	type Serialization = QuickbuildSerialization;
+    type Construction = QuickbuildConstruction;
+    type Serialization = QuickbuildSerialization;
 }

--- a/src/raknet/client/replica/racing_control.rs
+++ b/src/raknet/client/replica/racing_control.rs
@@ -1,146 +1,146 @@
 use std::io::{Read, Result as Res, Write};
 
-use endio::{Deserialize, LE, Serialize};
+use endio::{Deserialize, Serialize, LE};
 use endio_bit::{BEBitReader, BEBitWriter};
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
-use crate::common::{LuVarWString, LVec, ObjId};
-use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization, ReplicaD};
 use super::scripted_activity::ActivityUserInfo;
+use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization, ReplicaD};
+use crate::common::{LVec, LuVarWString, ObjId};
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct PreRacePlayerInfo {
-	pub player_id: ObjId,
-	pub vehicle_id: ObjId,
-	pub starting_position: u32,
-	pub is_ready: bool,
+    pub player_id: ObjId,
+    pub vehicle_id: ObjId,
+    pub starting_position: u32,
+    pub is_ready: bool,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct PostRacePlayerInfo {
-	pub player_id: ObjId,
-	pub current_rank: u32,
+    pub player_id: ObjId,
+    pub current_rank: u32,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct RaceInfo {
-	pub lap_count: u16,
-	pub path_name: LuVarWString<u16>,
+    pub lap_count: u16,
+    pub path_name: LuVarWString<u16>,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct DuringRacePlayerInfo {
-	pub player_id: ObjId,
-	pub best_lap_time: f32,
-	pub race_time: f32,
+    pub player_id: ObjId,
+    pub best_lap_time: f32,
+    pub race_time: f32,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq)]
 pub struct RacingControlConstruction {
-	pub activity_user_infos: Option<LVec<u32, ActivityUserInfo>>,
-	pub expected_player_count: Option<u16>,
-	pub pre_race_player_infos: Option<Vec<PreRacePlayerInfo>>,
-	pub post_race_player_infos: Option<Vec<PostRacePlayerInfo>>,
-	pub race_info: Option<RaceInfo>,
-	pub during_race_player_infos: Option<Vec<DuringRacePlayerInfo>>,
+    pub activity_user_infos: Option<LVec<u32, ActivityUserInfo>>,
+    pub expected_player_count: Option<u16>,
+    pub pre_race_player_infos: Option<Vec<PreRacePlayerInfo>>,
+    pub post_race_player_infos: Option<Vec<PostRacePlayerInfo>>,
+    pub race_info: Option<RaceInfo>,
+    pub during_race_player_infos: Option<Vec<DuringRacePlayerInfo>>,
 }
 
 impl<R: Read> Deserialize<LE, BEBitReader<R>> for RacingControlConstruction {
-	fn deserialize(reader: &mut BEBitReader<R>) -> Res<Self> {
-		let activity_user_infos = ReplicaD::deserialize(reader)?;
-		let expected_player_count = ReplicaD::deserialize(reader)?;
-		let pre_race_player_infos = if reader.read_bit()? {
-			let mut infos = vec![];
-			while reader.read_bit()? {
-				let info = ReplicaD::deserialize(reader)?;
-				infos.push(info);
-			}
-			Some(infos)
-		} else {
-			None
-		};
-		let post_race_player_infos = if reader.read_bit()? {
-			let mut infos = vec![];
-			while reader.read_bit()? {
-				let info = ReplicaD::deserialize(reader)?;
-				infos.push(info);
-			}
-			Some(infos)
-		} else {
-			None
-		};
-		let race_info = ReplicaD::deserialize(reader)?;
-		let during_race_player_infos = if reader.read_bit()? {
-			let mut infos = vec![];
-			while reader.read_bit()? {
-				let info = ReplicaD::deserialize(reader)?;
-				infos.push(info);
-			}
-			Some(infos)
-		} else {
-			None
-		};
-		Ok(Self {
-			activity_user_infos,
-			expected_player_count,
-			pre_race_player_infos,
-			post_race_player_infos,
-			race_info,
-			during_race_player_infos,
-		})
-	}
+    fn deserialize(reader: &mut BEBitReader<R>) -> Res<Self> {
+        let activity_user_infos = ReplicaD::deserialize(reader)?;
+        let expected_player_count = ReplicaD::deserialize(reader)?;
+        let pre_race_player_infos = if reader.read_bit()? {
+            let mut infos = vec![];
+            while reader.read_bit()? {
+                let info = ReplicaD::deserialize(reader)?;
+                infos.push(info);
+            }
+            Some(infos)
+        } else {
+            None
+        };
+        let post_race_player_infos = if reader.read_bit()? {
+            let mut infos = vec![];
+            while reader.read_bit()? {
+                let info = ReplicaD::deserialize(reader)?;
+                infos.push(info);
+            }
+            Some(infos)
+        } else {
+            None
+        };
+        let race_info = ReplicaD::deserialize(reader)?;
+        let during_race_player_infos = if reader.read_bit()? {
+            let mut infos = vec![];
+            while reader.read_bit()? {
+                let info = ReplicaD::deserialize(reader)?;
+                infos.push(info);
+            }
+            Some(infos)
+        } else {
+            None
+        };
+        Ok(Self {
+            activity_user_infos,
+            expected_player_count,
+            pre_race_player_infos,
+            post_race_player_infos,
+            race_info,
+            during_race_player_infos,
+        })
+    }
 }
 
 impl<'a, W: Write> Serialize<LE, BEBitWriter<W>> for &'a RacingControlConstruction {
-	fn serialize(self, writer: &mut BEBitWriter<W>) -> Res<()> {
-		crate::raknet::client::replica::ReplicaS::serialize(&self.activity_user_infos, writer)?;
-		crate::raknet::client::replica::ReplicaS::serialize(&self.expected_player_count, writer)?;
-		writer.write_bit(self.pre_race_player_infos.is_some())?;
-		if let Some(infos) = &self.pre_race_player_infos {
-			for info in infos {
-				writer.write_bit(true)?;
-				crate::raknet::client::replica::ReplicaS::serialize(info, writer)?;
-			}
-			writer.write_bit(false)?;
-		}
-		writer.write_bit(self.post_race_player_infos.is_some())?;
-		if let Some(infos) = &self.post_race_player_infos {
-			for info in infos {
-				writer.write_bit(true)?;
-				crate::raknet::client::replica::ReplicaS::serialize(info, writer)?;
-			}
-			writer.write_bit(false)?;
-		}
-		crate::raknet::client::replica::ReplicaS::serialize(&self.race_info, writer)?;
-		writer.write_bit(self.during_race_player_infos.is_some())?;
-		if let Some(infos) = &self.during_race_player_infos {
-			for info in infos {
-				writer.write_bit(true)?;
-				crate::raknet::client::replica::ReplicaS::serialize(info, writer)?;
-			}
-			writer.write_bit(false)?;
-		}
-		Ok(())
-	}
+    fn serialize(self, writer: &mut BEBitWriter<W>) -> Res<()> {
+        crate::raknet::client::replica::ReplicaS::serialize(&self.activity_user_infos, writer)?;
+        crate::raknet::client::replica::ReplicaS::serialize(&self.expected_player_count, writer)?;
+        writer.write_bit(self.pre_race_player_infos.is_some())?;
+        if let Some(infos) = &self.pre_race_player_infos {
+            for info in infos {
+                writer.write_bit(true)?;
+                crate::raknet::client::replica::ReplicaS::serialize(info, writer)?;
+            }
+            writer.write_bit(false)?;
+        }
+        writer.write_bit(self.post_race_player_infos.is_some())?;
+        if let Some(infos) = &self.post_race_player_infos {
+            for info in infos {
+                writer.write_bit(true)?;
+                crate::raknet::client::replica::ReplicaS::serialize(info, writer)?;
+            }
+            writer.write_bit(false)?;
+        }
+        crate::raknet::client::replica::ReplicaS::serialize(&self.race_info, writer)?;
+        writer.write_bit(self.during_race_player_infos.is_some())?;
+        if let Some(infos) = &self.during_race_player_infos {
+            for info in infos {
+                writer.write_bit(true)?;
+                crate::raknet::client::replica::ReplicaS::serialize(info, writer)?;
+            }
+            writer.write_bit(false)?;
+        }
+        Ok(())
+    }
 }
 
 impl ComponentConstruction for RacingControlConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub type RacingControlSerialization = RacingControlConstruction;
 
 impl ComponentSerialization for RacingControlSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct RacingControlProtocol;
 
 impl ComponentProtocol for RacingControlProtocol {
-	type Construction = RacingControlConstruction;
-	type Serialization = RacingControlSerialization;
+    type Construction = RacingControlConstruction;
+    type Serialization = RacingControlSerialization;
 }

--- a/src/raknet/client/replica/rigid_body_phantom_physics.rs
+++ b/src/raknet/client/replica/rigid_body_phantom_physics.rs
@@ -4,31 +4,31 @@ use endio::Serialize;
 use endio_bit::BEBitWriter;
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
-use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
 use super::simple_physics::PositionRotationInfo;
+use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct RigidBodyPhantomPhysicsConstruction {
-	pub position_rotation_info: Option<PositionRotationInfo>,
+    pub position_rotation_info: Option<PositionRotationInfo>,
 }
 
 impl ComponentConstruction for RigidBodyPhantomPhysicsConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		Serialize::serialize(self, writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        Serialize::serialize(self, writer)
+    }
 }
 
 pub type RigidBodyPhantomPhysicsSerialization = RigidBodyPhantomPhysicsConstruction;
 
 impl ComponentSerialization for RigidBodyPhantomPhysicsSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		Serialize::serialize(self, writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        Serialize::serialize(self, writer)
+    }
 }
 
 pub struct RigidBodyPhantomPhysicsProtocol;
 
 impl ComponentProtocol for RigidBodyPhantomPhysicsProtocol {
-	type Construction = RigidBodyPhantomPhysicsConstruction;
-	type Serialization = RigidBodyPhantomPhysicsSerialization;
+    type Construction = RigidBodyPhantomPhysicsConstruction;
+    type Serialization = RigidBodyPhantomPhysicsSerialization;
 }

--- a/src/raknet/client/replica/script.rs
+++ b/src/raknet/client/replica/script.rs
@@ -4,33 +4,32 @@ use endio::Serialize;
 use endio_bit::BEBitWriter;
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
-use crate::world::LuNameValue;
 use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
+use crate::world::LuNameValue;
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct ScriptConstruction {
-	pub network_vars: Option<LuNameValue>,
+    pub network_vars: Option<LuNameValue>,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
-pub struct ScriptSerialization {
-}
+pub struct ScriptSerialization {}
 
 impl ComponentConstruction for ScriptConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 impl ComponentSerialization for ScriptSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct ScriptProtocol;
 
 impl ComponentProtocol for ScriptProtocol {
-	type Construction = ScriptConstruction;
-	type Serialization = ScriptSerialization;
+    type Construction = ScriptConstruction;
+    type Serialization = ScriptSerialization;
 }

--- a/src/raknet/client/replica/scripted_activity.rs
+++ b/src/raknet/client/replica/scripted_activity.rs
@@ -4,48 +4,48 @@ use endio::Serialize;
 use endio_bit::BEBitWriter;
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
-use crate::common::{LVec, ObjId};
 use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
+use crate::common::{LVec, ObjId};
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct ActivityUserInfo {
-	pub user_object_id: ObjId,
-	// todo[min_const_generics]
-	// pub activity_values: [f32; 10],
-	pub activity_value_0: f32,
-	pub activity_value_1: f32,
-	pub activity_value_2: f32,
-	pub activity_value_3: f32,
-	pub activity_value_4: f32,
-	pub activity_value_5: f32,
-	pub activity_value_6: f32,
-	pub activity_value_7: f32,
-	pub activity_value_8: f32,
-	pub activity_value_9: f32,
+    pub user_object_id: ObjId,
+    // todo[min_const_generics]
+    // pub activity_values: [f32; 10],
+    pub activity_value_0: f32,
+    pub activity_value_1: f32,
+    pub activity_value_2: f32,
+    pub activity_value_3: f32,
+    pub activity_value_4: f32,
+    pub activity_value_5: f32,
+    pub activity_value_6: f32,
+    pub activity_value_7: f32,
+    pub activity_value_8: f32,
+    pub activity_value_9: f32,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct ScriptedActivityConstruction {
-	pub activity_user_infos: Option<LVec<u32, ActivityUserInfo>>,
+    pub activity_user_infos: Option<LVec<u32, ActivityUserInfo>>,
 }
 
 impl ComponentConstruction for ScriptedActivityConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub type ScriptedActivitySerialization = ScriptedActivityConstruction;
 
 impl ComponentSerialization for ScriptedActivitySerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct ScriptedActivityProtocol;
 
 impl ComponentProtocol for ScriptedActivityProtocol {
-	type Construction = ScriptedActivityConstruction;
-	type Serialization = ScriptedActivitySerialization;
+    type Construction = ScriptedActivityConstruction;
+    type Serialization = ScriptedActivitySerialization;
 }

--- a/src/raknet/client/replica/shooting_gallery.rs
+++ b/src/raknet/client/replica/shooting_gallery.rs
@@ -4,53 +4,53 @@ use endio::Serialize;
 use endio_bit::BEBitWriter;
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
+use super::scripted_activity::ActivityUserInfo;
+use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
 use crate::common::{LVec, ObjId};
 use crate::world::Vector3;
-use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
-use super::scripted_activity::ActivityUserInfo;
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct ShootingGalleryInfo {
-	pub velocity: f64,
-	pub cooldown: f64,
-	pub min_distance: f64,
-	pub muzzle_position: Vector3,
-	pub angle_to_fire: f32,
-	pub forward: Vector3,
-	pub user: ObjId,
-	pub activity_timer: f32,
-	pub camera_fov: f32,
+    pub velocity: f64,
+    pub cooldown: f64,
+    pub min_distance: f64,
+    pub muzzle_position: Vector3,
+    pub angle_to_fire: f32,
+    pub forward: Vector3,
+    pub user: ObjId,
+    pub activity_timer: f32,
+    pub camera_fov: f32,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct ShootingGalleryConstruction {
-	pub activity_user_infos: Option<LVec<u32, ActivityUserInfo>>,
-	pub camera_position: Vector3,
-	pub camera_look_at_position: Vector3,
-	pub shooting_gallery_info: Option<ShootingGalleryInfo>,
+    pub activity_user_infos: Option<LVec<u32, ActivityUserInfo>>,
+    pub camera_position: Vector3,
+    pub camera_look_at_position: Vector3,
+    pub shooting_gallery_info: Option<ShootingGalleryInfo>,
 }
 
 impl ComponentConstruction for ShootingGalleryConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct ShootingGallerySerialization {
-	pub activity_user_infos: Option<LVec<u32, ActivityUserInfo>>,
-	pub shooting_gallery_info: Option<ShootingGalleryInfo>,
+    pub activity_user_infos: Option<LVec<u32, ActivityUserInfo>>,
+    pub shooting_gallery_info: Option<ShootingGalleryInfo>,
 }
 
 impl ComponentSerialization for ShootingGallerySerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct ShootingGalleryProtocol;
 
 impl ComponentProtocol for ShootingGalleryProtocol {
-	type Construction = ShootingGalleryConstruction;
-	type Serialization = ShootingGallerySerialization;
+    type Construction = ShootingGalleryConstruction;
+    type Serialization = ShootingGallerySerialization;
 }

--- a/src/raknet/client/replica/simple_physics.rs
+++ b/src/raknet/client/replica/simple_physics.rs
@@ -4,72 +4,72 @@ use endio::{Deserialize, Serialize};
 use endio_bit::BEBitWriter;
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
-use crate::world::{Vector3, Quaternion};
 use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
+use crate::world::{Quaternion, Vector3};
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[repr(u32)]
 pub enum ClimbingProperty {
-	None,
-	Ladder,
-	ClimbWall,
-	ClimbWallStick,
+    None,
+    Ladder,
+    ClimbWall,
+    ClimbWallStick,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct VelocityInfo {
-	pub linear_velocity: Vector3,
-	pub angular_velocity: Vector3,
+    pub linear_velocity: Vector3,
+    pub angular_velocity: Vector3,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[repr(u32)]
 pub enum MotionType {
-	Dynamic = 1,
-	SphereInertia,
-	BoxInertia,
-	Keyframed,
-	Fixed,
-	ThinBoxInertia,
+    Dynamic = 1,
+    SphereInertia,
+    BoxInertia,
+    Keyframed,
+    Fixed,
+    ThinBoxInertia,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct PositionRotationInfo {
-	pub position: Vector3,
-	pub rotation: Quaternion,
+    pub position: Vector3,
+    pub rotation: Quaternion,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct SimplePhysicsConstruction {
-	pub is_climbable: bool,
-	pub climbing_property: ClimbingProperty,
-	pub velocity_info: Option<VelocityInfo>,
-	pub motion_type: Option<MotionType>,
-	pub position_rotation_info: Option<PositionRotationInfo>,
+    pub is_climbable: bool,
+    pub climbing_property: ClimbingProperty,
+    pub velocity_info: Option<VelocityInfo>,
+    pub motion_type: Option<MotionType>,
+    pub position_rotation_info: Option<PositionRotationInfo>,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct SimplePhysicsSerialization {
-	pub velocity_info: Option<VelocityInfo>,
-	pub motion_type: Option<MotionType>,
-	pub position_rotation_info: Option<PositionRotationInfo>,
+    pub velocity_info: Option<VelocityInfo>,
+    pub motion_type: Option<MotionType>,
+    pub position_rotation_info: Option<PositionRotationInfo>,
 }
 
 impl ComponentConstruction for SimplePhysicsConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		Serialize::serialize(self, writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        Serialize::serialize(self, writer)
+    }
 }
 
 impl ComponentSerialization for SimplePhysicsSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		Serialize::serialize(self, writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        Serialize::serialize(self, writer)
+    }
 }
 
 pub struct SimplePhysicsProtocol;
 
 impl ComponentProtocol for SimplePhysicsProtocol {
-	type Construction = SimplePhysicsConstruction;
-	type Serialization = SimplePhysicsSerialization;
+    type Construction = SimplePhysicsConstruction;
+    type Serialization = SimplePhysicsSerialization;
 }

--- a/src/raknet/client/replica/skill.rs
+++ b/src/raknet/client/replica/skill.rs
@@ -4,56 +4,56 @@ use endio::Serialize;
 use endio_bit::BEBitWriter;
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
-use crate::common::{LVec, ObjId};
 use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
+use crate::common::{LVec, ObjId};
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct BehaviorInfo {
-	pub unknown_1: u32,
-	pub action: u32, // todo: type
-	pub wait_time_ms: u32,
-	pub template_id: u32, // todo: type
-	pub caster: ObjId,
-	pub originator: ObjId,
-	pub target: ObjId,
-	pub used_mouse: bool,
-	pub cooldown: f32,
-	pub charge_time: f32,
-	pub imagination_cost: u32,
+    pub unknown_1: u32,
+    pub action: u32, // todo: type
+    pub wait_time_ms: u32,
+    pub template_id: u32, // todo: type
+    pub caster: ObjId,
+    pub originator: ObjId,
+    pub target: ObjId,
+    pub used_mouse: bool,
+    pub cooldown: f32,
+    pub charge_time: f32,
+    pub imagination_cost: u32,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct SkillInfo {
-	pub unknown_1: u32,
-	pub skill_id: u32, // todo: type
-	pub cast_type: u32, // todo: type
-	pub cancel_type: u32, // todo: type
-	pub behaviors: LVec<u32, BehaviorInfo>,
+    pub unknown_1: u32,
+    pub skill_id: u32,    // todo: type
+    pub cast_type: u32,   // todo: type
+    pub cancel_type: u32, // todo: type
+    pub behaviors: LVec<u32, BehaviorInfo>,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct SkillConstruction {
-	pub skills_in_progress: Option<LVec<u32, SkillInfo>>,
+    pub skills_in_progress: Option<LVec<u32, SkillInfo>>,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct SkillSerialization {}
 
 impl ComponentConstruction for SkillConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 impl ComponentSerialization for SkillSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct SkillProtocol;
 
 impl ComponentProtocol for SkillProtocol {
-	type Construction = SkillConstruction;
-	type Serialization = SkillSerialization;
+    type Construction = SkillConstruction;
+    type Serialization = SkillSerialization;
 }

--- a/src/raknet/client/replica/switch.rs
+++ b/src/raknet/client/replica/switch.rs
@@ -8,26 +8,26 @@ use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct SwitchConstruction {
-	pub is_active: bool,
+    pub is_active: bool,
 }
 
 impl ComponentConstruction for SwitchConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub type SwitchSerialization = SwitchConstruction;
 
 impl ComponentSerialization for SwitchSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct SwitchProtocol;
 
 impl ComponentProtocol for SwitchProtocol {
-	type Construction = SwitchConstruction;
-	type Serialization = SwitchSerialization;
+    type Construction = SwitchConstruction;
+    type Serialization = SwitchSerialization;
 }

--- a/src/raknet/client/replica/vehicle_physics.rs
+++ b/src/raknet/client/replica/vehicle_physics.rs
@@ -1,82 +1,82 @@
-use std::io::{Result as Res};
+use std::io::Result as Res;
 
 use endio::{Deserialize, Serialize};
 use endio_bit::BEBitWriter;
 use lu_packets_derive::{BitVariantTests, ReplicaSerde};
 
-use crate::world::{Vector3, Quaternion};
+use super::controllable_physics::LocalSpaceInfo;
 use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
-use super::controllable_physics::{LocalSpaceInfo};
+use crate::world::{Quaternion, Vector3};
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[repr(u8)]
 pub enum EndOfRaceBehaviorType {
-	DriveStraight,
-	StopStraight,
-	SlideLeft,
-	SlideRight,
-	Do360Left,
-	Do360Right,
-	TwoWheels,
-	Jump,
+    DriveStraight,
+    StopStraight,
+    SlideLeft,
+    SlideRight,
+    Do360Left,
+    Do360Right,
+    TwoWheels,
+    Jump,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct RemoteInputInfo {
-	pub remote_input_x: f32,
-	pub remote_input_y: f32,
-	pub do_powerslide: bool,
-	pub is_modified: bool,
+    pub remote_input_x: f32,
+    pub remote_input_y: f32,
+    pub do_powerslide: bool,
+    pub is_modified: bool,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct VehicleFrameStats {
-	pub position: Vector3,
-	pub rotation: Quaternion,
-	pub is_on_ground: bool,
-	pub is_on_rail: bool,
-	pub linear_velocity: Option<Vector3>,
-	pub angular_velocity: Option<Vector3>,
-	pub local_space_info: Option<LocalSpaceInfo>,
-	pub remote_input_info: Option<RemoteInputInfo>,
-	pub remote_input_ping: f32,
+    pub position: Vector3,
+    pub rotation: Quaternion,
+    pub is_on_ground: bool,
+    pub is_on_rail: bool,
+    pub linear_velocity: Option<Vector3>,
+    pub angular_velocity: Option<Vector3>,
+    pub local_space_info: Option<LocalSpaceInfo>,
+    pub remote_input_info: Option<RemoteInputInfo>,
+    pub remote_input_ping: f32,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct VehiclePhysicsConstruction {
-	pub vehicle_frame_stats: Option<VehicleFrameStats>,
-	pub end_of_race_behavior_type: EndOfRaceBehaviorType,
-	pub is_input_locked: bool,
-	pub wheel_lock_extra_friction: Option<bool>,
+    pub vehicle_frame_stats: Option<VehicleFrameStats>,
+    pub end_of_race_behavior_type: EndOfRaceBehaviorType,
+    pub is_input_locked: bool,
+    pub wheel_lock_extra_friction: Option<bool>,
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct VehicleFrameStatsTeleportInfo {
-	pub vehicle_frame_stats: VehicleFrameStats,
-	pub is_teleporting: bool,
+    pub vehicle_frame_stats: VehicleFrameStats,
+    pub is_teleporting: bool,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct VehiclePhysicsSerialization {
-	pub vehicle_frame_stats_teleport_info: Option<VehicleFrameStatsTeleportInfo>,
-	pub wheel_lock_extra_friction: Option<bool>,
+    pub vehicle_frame_stats_teleport_info: Option<VehicleFrameStatsTeleportInfo>,
+    pub wheel_lock_extra_friction: Option<bool>,
 }
 
 impl ComponentConstruction for VehiclePhysicsConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 impl ComponentSerialization for VehiclePhysicsSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct VehiclePhysicsProtocol;
 
 impl ComponentProtocol for VehiclePhysicsProtocol {
-	type Construction = VehiclePhysicsConstruction;
-	type Serialization = VehiclePhysicsSerialization;
+    type Construction = VehiclePhysicsConstruction;
+    type Serialization = VehiclePhysicsSerialization;
 }

--- a/src/raknet/client/replica/vendor.rs
+++ b/src/raknet/client/replica/vendor.rs
@@ -8,32 +8,32 @@ use super::{ComponentConstruction, ComponentProtocol, ComponentSerialization};
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct VendorInfo {
-	pub has_standard_items: bool,
-	pub has_multicost_items: bool,
+    pub has_standard_items: bool,
+    pub has_multicost_items: bool,
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
 pub struct VendorConstruction {
-	pub vendor_info: Option<VendorInfo>,
+    pub vendor_info: Option<VendorInfo>,
 }
 
 impl ComponentConstruction for VendorConstruction {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub type VendorSerialization = VendorConstruction;
 
 impl ComponentSerialization for VendorSerialization {
-	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
-		self.serialize(writer)
-	}
+    fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {
+        self.serialize(writer)
+    }
 }
 
 pub struct VendorProtocol;
 
 impl ComponentProtocol for VendorProtocol {
-	type Construction = VendorConstruction;
-	type Serialization = VendorSerialization;
+    type Construction = VendorConstruction;
+    type Serialization = VendorSerialization;
 }

--- a/src/raknet/mod.rs
+++ b/src/raknet/mod.rs
@@ -9,6 +9,6 @@ use endio::{Deserialize, Serialize};
 /// A combination of Ipv4Addr and port. todo: just use SocketAddrV4
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct SystemAddress {
-	pub ip: Ipv4Addr,
-	pub port: u16,
+    pub ip: Ipv4Addr,
+    pub port: u16,
 }

--- a/src/raknet/server/mod.rs
+++ b/src/raknet/server/mod.rs
@@ -1,9 +1,9 @@
 //! Server-received raknet messages.
-use std::io::{Read, Write};
 use std::io::Result as Res;
+use std::io::{Read, Write};
 
-use endio::{Deserialize, Serialize};
 use endio::LittleEndian as LE;
+use endio::{Deserialize, Serialize};
 use lu_packets_derive::VariantTests;
 
 use super::SystemAddress;
@@ -13,41 +13,41 @@ use super::SystemAddress;
 #[non_exhaustive]
 #[repr(u8)]
 pub enum Message<U> {
-	InternalPing(InternalPing) = 0,
-	ConnectionRequest(ConnectionRequest) = 4,
-	NewIncomingConnection(NewIncomingConnection) = 17,
-	DisconnectionNotification = 19,
-	UserMessage(U) = 83,
+    InternalPing(InternalPing) = 0,
+    ConnectionRequest(ConnectionRequest) = 4,
+    NewIncomingConnection(NewIncomingConnection) = 17,
+    DisconnectionNotification = 19,
+    UserMessage(U) = 83,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct InternalPing {
-	pub send_time: u32
+    pub send_time: u32,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct ConnectionRequest {
-	pub password: Box<[u8]>
+    pub password: Box<[u8]>,
 }
 
 impl<R: Read> Deserialize<LE, R> for ConnectionRequest {
-	fn deserialize(reader: &mut R) -> Res<Self> {
-		let mut password = vec![];
-		reader.read_to_end(&mut password)?;
-		let password = password.into_boxed_slice();
-		Ok(Self { password })
-	}
+    fn deserialize(reader: &mut R) -> Res<Self> {
+        let mut password = vec![];
+        reader.read_to_end(&mut password)?;
+        let password = password.into_boxed_slice();
+        Ok(Self { password })
+    }
 }
 
 impl<'a, W: Write> Serialize<LE, W> for &'a ConnectionRequest {
-	fn serialize(self, writer: &mut W) -> Res<()> {
-		writer.write_all(&self.password)?;
-		Ok(())
-	}
+    fn serialize(self, writer: &mut W) -> Res<()> {
+        writer.write_all(&self.password)?;
+        Ok(())
+    }
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct NewIncomingConnection {
-	pub peer_addr: SystemAddress,
-	pub local_addr: SystemAddress,
+    pub peer_addr: SystemAddress,
+    pub local_addr: SystemAddress,
 }

--- a/src/world/amf3.rs
+++ b/src/world/amf3.rs
@@ -148,7 +148,7 @@ impl<R: Read> Deserialize<LE, Amf3Reader<'_, R>> for Amf3String {
                 Ok(x) => x,
                 Err(_) => return Err(Error::new(InvalidData, "string is not valid utf8")),
             };
-            if string != "" {
+            if !string.is_empty() {
                 reader.string_ref_table.push(Self(string.clone()));
             }
             string
@@ -160,7 +160,7 @@ impl<R: Read> Deserialize<LE, Amf3Reader<'_, R>> for Amf3String {
 
 impl<'a, W: Write> Serialize<LE, Amf3Writer<'_, W>> for &'a Amf3String {
     fn serialize(self, writer: &mut Amf3Writer<'_, W>) -> Res<()> {
-        if self.0 == "" {
+        if self.0.is_empty() {
             let length_and_is_inline = U29(1);
             return LEWrite::write(writer, &length_and_is_inline);
         }
@@ -184,7 +184,7 @@ impl<'a, W: Write> Serialize<LE, Amf3Writer<'_, W>> for &'a Amf3String {
 
     [See spec section 3.11 for more](https://wwwimages2.adobe.com/content/dam/acom/en/devnet/pdf/amf-file-format-spec.pdf#%5B%7B%22num%22%3A24%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C720%2C0%5D).
 */
-#[derive(Clone, PartialEq)]
+#[derive(Clone, Default, PartialEq)]
 pub struct Amf3Array {
     pub map: HashMap<Amf3String, Amf3>,
     pub vec: Vec<Amf3>,
@@ -192,10 +192,7 @@ pub struct Amf3Array {
 
 impl Amf3Array {
     pub fn new() -> Self {
-        Self {
-            map: HashMap::new(),
-            vec: vec![],
-        }
+        Self::default()
     }
 }
 
@@ -262,7 +259,7 @@ impl<R: Read> Deserialize<LE, Amf3Reader<'_, R>> for Amf3Array {
         let mut map = HashMap::new();
         loop {
             let key: Amf3String = LERead::read(reader)?;
-            if key.0 == "" {
+            if key.0.is_empty() {
                 break;
             }
             let value = deser_amf3(reader)?;

--- a/src/world/amf3.rs
+++ b/src/world/amf3.rs
@@ -6,33 +6,33 @@ use std::fmt::{Debug, Formatter, Result as FmtResult};
 use std::io::{Error, ErrorKind::InvalidData, Read, Result as Res, Write};
 use std::ops::{Index, IndexMut};
 
-use endio::{Deserialize, LE, LERead, LEWrite, Serialize};
+use endio::{Deserialize, LERead, LEWrite, Serialize, LE};
 use lu_packets_derive::GmParam;
 
 struct Amf3Reader<'a, R: Read> {
-	inner: &'a mut R,
-	string_ref_table: Vec<Amf3String>,
+    inner: &'a mut R,
+    string_ref_table: Vec<Amf3String>,
 }
 
 impl<R: Read> Read for Amf3Reader<'_, R> {
-	fn read(&mut self, buf: &mut [u8]) -> Res<usize> {
-		self.inner.read(buf)
-	}
+    fn read(&mut self, buf: &mut [u8]) -> Res<usize> {
+        self.inner.read(buf)
+    }
 }
 
 struct Amf3Writer<'a, W: Write> {
-	inner: &'a mut W,
-	string_ref_table: Vec<Amf3String>,
+    inner: &'a mut W,
+    string_ref_table: Vec<Amf3String>,
 }
 
 impl<W: Write> Write for Amf3Writer<'_, W> {
-	fn write(&mut self, buf: &[u8]) -> Res<usize> {
-		self.inner.write(buf)
-	}
+    fn write(&mut self, buf: &[u8]) -> Res<usize> {
+        self.inner.write(buf)
+    }
 
-	fn flush(&mut self) -> Res<()> {
-		self.inner.flush()
-	}
+    fn flush(&mut self) -> Res<()> {
+        self.inner.flush()
+    }
 }
 
 /// An error returned when an integer is too large to be represented by an `U29`.
@@ -45,356 +45,396 @@ struct U29(u32);
 
 /// Converts the value to a [`U29`] if it is less than 2^29, returns [`U29Error`] otherwise.
 impl TryFrom<usize> for U29 {
-	type Error = U29Error;
+    type Error = U29Error;
 
-	fn try_from(value: usize) -> Result<Self, Self::Error> {
-		if value >= 1 << 29 {
-			Err(U29Error)
-		} else {
-			Ok(Self(value as u32))
-		}
-	}
+    fn try_from(value: usize) -> Result<Self, Self::Error> {
+        if value >= 1 << 29 {
+            Err(U29Error)
+        } else {
+            Ok(Self(value as u32))
+        }
+    }
 }
 
 impl<R: Read> Deserialize<LE, R> for U29 {
-	fn deserialize(reader: &mut R) -> Res<Self> {
-		let mut value = 0;
-		for _ in 0..3 {
-			let byte: u8 = LERead::read(reader)?;
-			let byte = byte as u32;
-			value = (value << 7) | (byte & 0x7f);
-			if byte & 0x80 == 0 {
-				return Ok(Self(value));
-			}
-		}
-		let byte: u8 = LERead::read(reader)?;
-		let byte = byte as u32;
-		value = (value << 8) | byte;
-		Ok(Self(value))
-	}
+    fn deserialize(reader: &mut R) -> Res<Self> {
+        let mut value = 0;
+        for _ in 0..3 {
+            let byte: u8 = LERead::read(reader)?;
+            let byte = byte as u32;
+            value = (value << 7) | (byte & 0x7f);
+            if byte & 0x80 == 0 {
+                return Ok(Self(value));
+            }
+        }
+        let byte: u8 = LERead::read(reader)?;
+        let byte = byte as u32;
+        value = (value << 8) | byte;
+        Ok(Self(value))
+    }
 }
 
 impl<'a, W: Write> Serialize<LE, W> for &'a U29 {
-	fn serialize(self, writer: &mut W) -> Res<()> {
-		let v = self.0;
-		if v <= 0x7f {
-			LEWrite::write(writer, v as u8)
-		} else if v <= 0x3fff {
-			LEWrite::write(writer, (v >> 7) as u8 | 0x80)?;
-			LEWrite::write(writer, v as u8 & 0x7f)
-		} else if v <= 0x1fffff {
-			LEWrite::write(writer, (v >> 14) as u8 | 0x80)?;
-			LEWrite::write(writer, (v >> 7 ) as u8 | 0x80)?;
-			LEWrite::write(writer, v as u8 & 0x7f)
-		} else {
-			LEWrite::write(writer, (v >> 22) as u8 | 0x80)?;
-			LEWrite::write(writer, (v >> 15) as u8 | 0x80)?;
-			LEWrite::write(writer, (v >> 8 ) as u8 | 0x80)?;
-			LEWrite::write(writer, v as u8)
-		}
-	}
+    fn serialize(self, writer: &mut W) -> Res<()> {
+        let v = self.0;
+        if v <= 0x7f {
+            LEWrite::write(writer, v as u8)
+        } else if v <= 0x3fff {
+            LEWrite::write(writer, (v >> 7) as u8 | 0x80)?;
+            LEWrite::write(writer, v as u8 & 0x7f)
+        } else if v <= 0x1fffff {
+            LEWrite::write(writer, (v >> 14) as u8 | 0x80)?;
+            LEWrite::write(writer, (v >> 7) as u8 | 0x80)?;
+            LEWrite::write(writer, v as u8 & 0x7f)
+        } else {
+            LEWrite::write(writer, (v >> 22) as u8 | 0x80)?;
+            LEWrite::write(writer, (v >> 15) as u8 | 0x80)?;
+            LEWrite::write(writer, (v >> 8) as u8 | 0x80)?;
+            LEWrite::write(writer, v as u8)
+        }
+    }
 }
 
 /**
-	A string with a maximum length of 2^29-1.
+    A string with a maximum length of 2^29-1.
 
-	[See spec section 3.8 for more](https://wwwimages2.adobe.com/content/dam/acom/en/devnet/pdf/amf-file-format-spec.pdf#%5B%7B%22num%22%3A22%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C196%2C0%5D).
+    [See spec section 3.8 for more](https://wwwimages2.adobe.com/content/dam/acom/en/devnet/pdf/amf-file-format-spec.pdf#%5B%7B%22num%22%3A22%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C196%2C0%5D).
 */
 #[derive(Clone, Eq, Hash, Ord, PartialEq, PartialOrd)]
 pub struct Amf3String(String);
 
 impl Debug for Amf3String {
-	fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-		self.0.fmt(f)
-	}
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        self.0.fmt(f)
+    }
 }
 
 impl Borrow<str> for Amf3String {
-	fn borrow(&self) -> &str {
-		&self.0[..]
-	}
+    fn borrow(&self) -> &str {
+        &self.0[..]
+    }
 }
 
 impl TryFrom<&str> for Amf3String {
-	type Error = U29Error;
+    type Error = U29Error;
 
-	fn try_from(string: &str) -> Result<Self, Self::Error> {
-		if string.len() & (1 << 29) != 0 {
-			Err(U29Error)
-		} else {
-			Ok(Self(string.into()))
-		}
-	}
+    fn try_from(string: &str) -> Result<Self, Self::Error> {
+        if string.len() & (1 << 29) != 0 {
+            Err(U29Error)
+        } else {
+            Ok(Self(string.into()))
+        }
+    }
 }
 
 impl<R: Read> Deserialize<LE, Amf3Reader<'_, R>> for Amf3String {
-	fn deserialize(reader: &mut Amf3Reader<'_, R>) -> Res<Self> {
-		let value_and_is_inline: U29 = LERead::read(reader)?;
-		let is_inline = value_and_is_inline.0 & 0x01 == 1;
-		let value = value_and_is_inline.0 >> 1;
-		let string = if !is_inline {
-			let index = value;
-			match reader.string_ref_table.get(index as usize) {
-				Some(x) => x.0.clone(),
-				None => { return Err(Error::new(InvalidData, "invalid reference index")) }
-			}
-		} else {
-			let length = value;
+    fn deserialize(reader: &mut Amf3Reader<'_, R>) -> Res<Self> {
+        let value_and_is_inline: U29 = LERead::read(reader)?;
+        let is_inline = value_and_is_inline.0 & 0x01 == 1;
+        let value = value_and_is_inline.0 >> 1;
+        let string = if !is_inline {
+            let index = value;
+            match reader.string_ref_table.get(index as usize) {
+                Some(x) => x.0.clone(),
+                None => return Err(Error::new(InvalidData, "invalid reference index")),
+            }
+        } else {
+            let length = value;
 
-			let mut vec = vec![0u8; length as usize];
-			Read::read_exact(reader, &mut vec)?;
+            let mut vec = vec![0u8; length as usize];
+            Read::read_exact(reader, &mut vec)?;
 
-			let string = match String::from_utf8(vec) {
-				Ok(x) => x,
-				Err(_) => { return Err(Error::new(InvalidData, "string is not valid utf8")) }
-			};
-			if string != "" {
-				reader.string_ref_table.push(Self(string.clone()));
-			}
-			string
-		};
+            let string = match String::from_utf8(vec) {
+                Ok(x) => x,
+                Err(_) => return Err(Error::new(InvalidData, "string is not valid utf8")),
+            };
+            if string != "" {
+                reader.string_ref_table.push(Self(string.clone()));
+            }
+            string
+        };
 
-		Ok(Self(string))
-	}
+        Ok(Self(string))
+    }
 }
 
 impl<'a, W: Write> Serialize<LE, Amf3Writer<'_, W>> for &'a Amf3String {
-	fn serialize(self, writer: &mut Amf3Writer<'_, W>) -> Res<()> {
-		if self.0 == "" {
-			let length_and_is_inline = U29(1);
-			return LEWrite::write(writer, &length_and_is_inline);
-		}
-		match writer.string_ref_table.iter().position(|x| x == self) {
-			Some(index) => {
-				let index_and_is_inline = U29((index as u32) << 1);
-				LEWrite::write(writer, &index_and_is_inline)
-			}
-			None => {
-				let length_and_is_inline = U29((self.0.len() as u32) << 1 | 1);
-				LEWrite::write(writer, &length_and_is_inline)?;
-				writer.string_ref_table.push(Amf3String(self.0.clone()));
-				Write::write_all(writer, self.0.as_bytes())
-			}
-		}
-	}
+    fn serialize(self, writer: &mut Amf3Writer<'_, W>) -> Res<()> {
+        if self.0 == "" {
+            let length_and_is_inline = U29(1);
+            return LEWrite::write(writer, &length_and_is_inline);
+        }
+        match writer.string_ref_table.iter().position(|x| x == self) {
+            Some(index) => {
+                let index_and_is_inline = U29((index as u32) << 1);
+                LEWrite::write(writer, &index_and_is_inline)
+            }
+            None => {
+                let length_and_is_inline = U29((self.0.len() as u32) << 1 | 1);
+                LEWrite::write(writer, &length_and_is_inline)?;
+                writer.string_ref_table.push(Amf3String(self.0.clone()));
+                Write::write_all(writer, self.0.as_bytes())
+            }
+        }
+    }
 }
 
 /**
-	Both a dense and associative array at the same time.
+    Both a dense and associative array at the same time.
 
-	[See spec section 3.11 for more](https://wwwimages2.adobe.com/content/dam/acom/en/devnet/pdf/amf-file-format-spec.pdf#%5B%7B%22num%22%3A24%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C720%2C0%5D).
+    [See spec section 3.11 for more](https://wwwimages2.adobe.com/content/dam/acom/en/devnet/pdf/amf-file-format-spec.pdf#%5B%7B%22num%22%3A24%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C720%2C0%5D).
 */
 #[derive(Clone, PartialEq)]
 pub struct Amf3Array {
-	pub map: HashMap<Amf3String, Amf3>,
-	pub vec: Vec<Amf3>,
+    pub map: HashMap<Amf3String, Amf3>,
+    pub vec: Vec<Amf3>,
 }
 
 impl Amf3Array {
-	pub fn new() -> Self {
-		Self { map: HashMap::new(), vec: vec![] }
-	}
+    pub fn new() -> Self {
+        Self {
+            map: HashMap::new(),
+            vec: vec![],
+        }
+    }
 }
 
 impl Debug for Amf3Array {
-	fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-		let map_empty = self.map.is_empty();
-		let vec_empty = self.vec.is_empty();
-		if !map_empty && vec_empty {
-			write!(f, "amf3! ")?;
-			self.map.fmt(f)
-		} else if map_empty && !vec_empty {
-			write!(f, "amf3! ")?;
-			self.vec.fmt(f)
-		} else if map_empty && vec_empty {
-			write!(f, "amf3! {{}}")
-		} else {
-			write!(f, "Amf3Array {{ map: {:?}, vec: {:?} }}", self.map, self.vec)
-		}
-	}
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        let map_empty = self.map.is_empty();
+        let vec_empty = self.vec.is_empty();
+        if !map_empty && vec_empty {
+            write!(f, "amf3! ")?;
+            self.map.fmt(f)
+        } else if map_empty && !vec_empty {
+            write!(f, "amf3! ")?;
+            self.vec.fmt(f)
+        } else if map_empty && vec_empty {
+            write!(f, "amf3! {{}}")
+        } else {
+            write!(
+                f,
+                "Amf3Array {{ map: {:?}, vec: {:?} }}",
+                self.map, self.vec
+            )
+        }
+    }
 }
 
 impl Index<usize> for Amf3Array {
-	type Output = Amf3;
+    type Output = Amf3;
 
-	fn index(&self, index: usize) -> &Self::Output {
-		&self.vec[index]
-	}
+    fn index(&self, index: usize) -> &Self::Output {
+        &self.vec[index]
+    }
 }
 
 impl IndexMut<usize> for Amf3Array {
-	fn index_mut(&mut self, index: usize) -> &mut Self::Output {
-		&mut self.vec[index]
-	}
+    fn index_mut(&mut self, index: usize) -> &mut Self::Output {
+        &mut self.vec[index]
+    }
 }
 
 impl Index<&Amf3String> for Amf3Array {
-	type Output = Amf3;
+    type Output = Amf3;
 
-	fn index(&self, key: &Amf3String) -> &Amf3 {
-		&self.map[key]
-	}
+    fn index(&self, key: &Amf3String) -> &Amf3 {
+        &self.map[key]
+    }
 }
 
 impl Index<&str> for Amf3Array {
-	type Output = Amf3;
+    type Output = Amf3;
 
-	fn index(&self, key: &str) -> &Amf3 {
-		&self.map[key]
-	}
+    fn index(&self, key: &str) -> &Amf3 {
+        &self.map[key]
+    }
 }
 
 impl<R: Read> Deserialize<LE, Amf3Reader<'_, R>> for Amf3Array {
-	fn deserialize(reader: &mut Amf3Reader<'_, R>) -> Res<Self> {
-		let length_and_is_inline: U29 = LERead::read(reader)?;
-		let is_inline = length_and_is_inline.0 & 0x01 == 1;
-		let length = length_and_is_inline.0 >> 1;
-		if !is_inline { todo!() }
-		let mut map = HashMap::new();
-		loop {
-			let key: Amf3String = LERead::read(reader)?;
-			if key.0 == "" {
-				break;
-			}
-			let value = deser_amf3(reader)?;
-			map.insert(key, value);
-		}
-		let mut vec = Vec::with_capacity(length as usize);
-		for _ in 0..length {
-			let value = deser_amf3(reader)?;
-			vec.push(value);
-		}
+    fn deserialize(reader: &mut Amf3Reader<'_, R>) -> Res<Self> {
+        let length_and_is_inline: U29 = LERead::read(reader)?;
+        let is_inline = length_and_is_inline.0 & 0x01 == 1;
+        let length = length_and_is_inline.0 >> 1;
+        if !is_inline {
+            todo!()
+        }
+        let mut map = HashMap::new();
+        loop {
+            let key: Amf3String = LERead::read(reader)?;
+            if key.0 == "" {
+                break;
+            }
+            let value = deser_amf3(reader)?;
+            map.insert(key, value);
+        }
+        let mut vec = Vec::with_capacity(length as usize);
+        for _ in 0..length {
+            let value = deser_amf3(reader)?;
+            vec.push(value);
+        }
 
-		Ok(Self { map, vec })
-	}
+        Ok(Self { map, vec })
+    }
 }
 
 impl<'a, W: Write> Serialize<LE, Amf3Writer<'_, W>> for &'a Amf3Array {
-	fn serialize(self, writer: &mut Amf3Writer<'_, W>) -> Res<()> {
-		let length_and_is_inline = U29((self.vec.len() as u32) << 1 | 1);
-		LEWrite::write(writer, &length_and_is_inline)?;
-		#[cfg(test)]
-		let key_value = {
-			let mut key_value: Vec<_> = self.map.iter().collect();
-			key_value.sort_unstable_by(|(k1, _), (k2, _)| k1.cmp(k2));
-			key_value
-		};
-		#[cfg(not(test))]
-		let key_value = self.map.iter();
-		for (key, value) in key_value {
-			LEWrite::write(writer, key)?;
-			ser_amf3(writer, value)?;
-		}
-		LEWrite::write(writer, &Amf3String("".into()))?;
-		for value in &self.vec {
-			ser_amf3(writer, value)?;
-		}
-		Ok(())
-	}
+    fn serialize(self, writer: &mut Amf3Writer<'_, W>) -> Res<()> {
+        let length_and_is_inline = U29((self.vec.len() as u32) << 1 | 1);
+        LEWrite::write(writer, &length_and_is_inline)?;
+        #[cfg(test)]
+        let key_value = {
+            let mut key_value: Vec<_> = self.map.iter().collect();
+            key_value.sort_unstable_by(|(k1, _), (k2, _)| k1.cmp(k2));
+            key_value
+        };
+        #[cfg(not(test))]
+        let key_value = self.map.iter();
+        for (key, value) in key_value {
+            LEWrite::write(writer, key)?;
+            ser_amf3(writer, value)?;
+        }
+        LEWrite::write(writer, &Amf3String("".into()))?;
+        for value in &self.vec {
+            ser_amf3(writer, value)?;
+        }
+        Ok(())
+    }
 }
 /**
-	A type that can be (de-)serialized in the AMF3 format.
+    A type that can be (de-)serialized in the AMF3 format.
 
-	[See spec section 3 for more](https://wwwimages2.adobe.com/content/dam/acom/en/devnet/pdf/amf-file-format-spec.pdf#%5B%7B%22num%22%3A20%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C305%2C0%5D).
+    [See spec section 3 for more](https://wwwimages2.adobe.com/content/dam/acom/en/devnet/pdf/amf-file-format-spec.pdf#%5B%7B%22num%22%3A20%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C88%2C305%2C0%5D).
 */
 #[derive(Clone, GmParam, PartialEq)]
 #[repr(u8)]
 pub enum Amf3 {
-	False = 2,
-	True = 3,
-	Double(f64) = 5,
-	String(Amf3String) = 6,
-	Array(Amf3Array) = 9,
+    False = 2,
+    True = 3,
+    Double(f64) = 5,
+    String(Amf3String) = 6,
+    Array(Amf3Array) = 9,
 }
 
 impl Debug for Amf3 {
-	fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
-		match self {
-			Self::False     => write!(f, "false"),
-			Self::True      => write!(f, "true"),
-			Self::Double(x) => x.fmt(f),
-			Self::String(x) => x.fmt(f),
-			Self::Array (x) => x.fmt(f),
-		}
-	}
+    fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
+        match self {
+            Self::False => write!(f, "false"),
+            Self::True => write!(f, "true"),
+            Self::Double(x) => x.fmt(f),
+            Self::String(x) => x.fmt(f),
+            Self::Array(x) => x.fmt(f),
+        }
+    }
 }
 
 impl<R: Read> Deserialize<LE, R> for Amf3 {
-	fn deserialize(reader: &mut R) -> Res<Self> {
-		let mut reader = Amf3Reader { inner: reader, string_ref_table: vec![] };
-		deser_amf3(&mut reader)
-	}
+    fn deserialize(reader: &mut R) -> Res<Self> {
+        let mut reader = Amf3Reader {
+            inner: reader,
+            string_ref_table: vec![],
+        };
+        deser_amf3(&mut reader)
+    }
 }
 
 fn deser_amf3<R: Read>(reader: &mut Amf3Reader<R>) -> Res<Amf3> {
-	let disc: u8 = LERead::read(reader)?;
-	Ok(match disc {
-		2 => Amf3::False,
-		3 => Amf3::True,
-		5 => Amf3::Double(LERead::read(reader)?),
-		6 => Amf3::String(LERead::read(reader)?),
-		9 => Amf3::Array (LERead::read(reader)?),
-		_ => { return Err(Error::new(InvalidData, format!("invalid discriminant value for Amf3: {}", disc))) }
-	})
+    let disc: u8 = LERead::read(reader)?;
+    Ok(match disc {
+        2 => Amf3::False,
+        3 => Amf3::True,
+        5 => Amf3::Double(LERead::read(reader)?),
+        6 => Amf3::String(LERead::read(reader)?),
+        9 => Amf3::Array(LERead::read(reader)?),
+        _ => {
+            return Err(Error::new(
+                InvalidData,
+                format!("invalid discriminant value for Amf3: {}", disc),
+            ))
+        }
+    })
 }
 
 impl<'a, W: Write> Serialize<LE, W> for &'a Amf3 {
-	fn serialize(self, writer: &mut W) -> Res<()> {
-		let mut writer = Amf3Writer { inner: writer, string_ref_table: vec![] };
-		ser_amf3(&mut writer, self)
-	}
+    fn serialize(self, writer: &mut W) -> Res<()> {
+        let mut writer = Amf3Writer {
+            inner: writer,
+            string_ref_table: vec![],
+        };
+        ser_amf3(&mut writer, self)
+    }
 }
 
 fn ser_amf3<W: Write>(writer: &mut Amf3Writer<W>, amf3: &Amf3) -> Res<()> {
-	match amf3 {
-		Amf3::False     =>   LEWrite::write(writer, 2u8),
-		Amf3::True      =>   LEWrite::write(writer, 3u8),
-		Amf3::Double(x) => { LEWrite::write(writer, 5u8)?; LEWrite::write(writer, x) },
-		Amf3::String(x) => { LEWrite::write(writer, 6u8)?; LEWrite::write(writer, x) },
-		Amf3::Array (x) => { LEWrite::write(writer, 9u8)?; LEWrite::write(writer, x) },
-	}
+    match amf3 {
+        Amf3::False => LEWrite::write(writer, 2u8),
+        Amf3::True => LEWrite::write(writer, 3u8),
+        Amf3::Double(x) => {
+            LEWrite::write(writer, 5u8)?;
+            LEWrite::write(writer, x)
+        }
+        Amf3::String(x) => {
+            LEWrite::write(writer, 6u8)?;
+            LEWrite::write(writer, x)
+        }
+        Amf3::Array(x) => {
+            LEWrite::write(writer, 9u8)?;
+            LEWrite::write(writer, x)
+        }
+    }
 }
 
 impl From<bool> for Amf3 {
-	fn from(b: bool) -> Self {
-		if b { Self::True } else { Self::False }
-	}
+    fn from(b: bool) -> Self {
+        if b {
+            Self::True
+        } else {
+            Self::False
+        }
+    }
 }
 
 impl From<f32> for Amf3 {
-	fn from(f: f32) -> Self {
-		Self::Double(f.into())
-	}
+    fn from(f: f32) -> Self {
+        Self::Double(f.into())
+    }
 }
 
 impl From<f64> for Amf3 {
-	fn from(f: f64) -> Self {
-		Self::Double(f)
-	}
+    fn from(f: f64) -> Self {
+        Self::Double(f)
+    }
 }
 
 impl TryFrom<&str> for Amf3 {
-	type Error = U29Error;
+    type Error = U29Error;
 
-	fn try_from(string: &str) -> Result<Self, Self::Error> {
-		Ok(Self::String(string.try_into()?))
-	}
+    fn try_from(string: &str) -> Result<Self, Self::Error> {
+        Ok(Self::String(string.try_into()?))
+    }
 }
 
 #[cfg(test)]
 mod tests {
-	use endio::{LERead, LEWrite};
-	use super::U29;
+    use super::U29;
+    use endio::{LERead, LEWrite};
 
-	#[test]
-	fn test_u29() {
-		for (bytes, integer) in &[(&b"\x7f"[..], 0x7f), (&b"\xa2\x43"[..], 4419), (&b"\x88\x00"[..], 1024), (&b"\xff\xff\x7e"[..], 0x1ffffe), (&b"\x80\xc0\x80\x00"[..], 0x200000), (&b"\xbf\xff\xff\xfe"[..], 0xffffffe)] {
-			let mut reader = &bytes[..];
-			let val: U29 = reader.read().unwrap();
-			assert_eq!(val.0, *integer);
-			let mut writer = vec![];
-			writer.write(&val).unwrap();
-			assert_eq!(&&writer[..], bytes);
-		}
-	}
+    #[test]
+    fn test_u29() {
+        for (bytes, integer) in &[
+            (&b"\x7f"[..], 0x7f),
+            (&b"\xa2\x43"[..], 4419),
+            (&b"\x88\x00"[..], 1024),
+            (&b"\xff\xff\x7e"[..], 0x1ffffe),
+            (&b"\x80\xc0\x80\x00"[..], 0x200000),
+            (&b"\xbf\xff\xff\xfe"[..], 0xffffffe),
+        ] {
+            let mut reader = &bytes[..];
+            let val: U29 = reader.read().unwrap();
+            assert_eq!(val.0, *integer);
+            let mut writer = vec![];
+            writer.write(&val).unwrap();
+            assert_eq!(&&writer[..], bytes);
+        }
+    }
 }

--- a/src/world/client/mod.rs
+++ b/src/world/client/mod.rs
@@ -1,17 +1,17 @@
 //! Client-received world messages.
-use std::io::{Error, ErrorKind::InvalidData, Read, Write};
 use std::io::Result as Res;
+use std::io::{Error, ErrorKind::InvalidData, Read, Write};
 
-use endio::{Deserialize, LERead, LEWrite, Serialize};
 use endio::LittleEndian as LE;
+use endio::{Deserialize, LERead, LEWrite, Serialize};
 use lu_packets_derive::{MessageFromVariants, VariantTests};
 
-use crate::chat::ChatChannel;
-use crate::chat::client::ChatMessage;
-use crate::common::{ObjId, LuString33, LuWString33, LuWString42, LVec, ServiceId};
-use crate::general::client::{DisconnectNotify, Handshake, GeneralMessage};
-use super::{Lot, lnv::LuNameValue, Vector3, ZoneId};
 use super::gm::client::SubjectGameMessage;
+use super::{lnv::LuNameValue, Lot, Vector3, ZoneId};
+use crate::chat::client::ChatMessage;
+use crate::chat::ChatChannel;
+use crate::common::{LVec, LuString33, LuWString33, LuWString42, ObjId, ServiceId};
+use crate::general::client::{DisconnectNotify, GeneralMessage, Handshake};
 
 /// All messages that can be received by a client from a world server.
 pub type Message = crate::raknet::client::Message<LuMessage>;
@@ -20,565 +20,602 @@ pub type Message = crate::raknet::client::Message<LuMessage>;
 #[derive(Debug, Deserialize, MessageFromVariants, PartialEq, Serialize, VariantTests)]
 #[repr(u16)]
 pub enum LuMessage {
-	General(GeneralMessage) = ServiceId::General as u16,
-	Chat(ChatMessage) = ServiceId::Chat as u16,
-	Client(ClientMessage) = ServiceId::Client as u16,
+    General(GeneralMessage) = ServiceId::General as u16,
+    Chat(ChatMessage) = ServiceId::Chat as u16,
+    Client(ClientMessage) = ServiceId::Client as u16,
 }
 
 impl From<LuMessage> for Message {
-	fn from(msg: LuMessage) -> Self {
-		Message::UserMessage(msg)
-	}
+    fn from(msg: LuMessage) -> Self {
+        Message::UserMessage(msg)
+    }
 }
 
 impl From<Handshake> for Message {
-	fn from(msg: Handshake) -> Self {
-		GeneralMessage::Handshake(msg).into()
-	}
+    fn from(msg: Handshake) -> Self {
+        GeneralMessage::Handshake(msg).into()
+    }
 }
 
 impl From<DisconnectNotify> for Message {
-	fn from(msg: DisconnectNotify) -> Self {
-		GeneralMessage::DisconnectNotify(msg).into()
-	}
+    fn from(msg: DisconnectNotify) -> Self {
+        GeneralMessage::DisconnectNotify(msg).into()
+    }
 }
 
 /// All client-received world messages.
 #[derive(Debug, Deserialize, PartialEq, Serialize, MessageFromVariants, VariantTests)]
 #[non_exhaustive]
-#[post_disc_padding=1]
+#[post_disc_padding = 1]
 #[repr(u32)]
 pub enum ClientMessage {
-	LoadStaticZone(LoadStaticZone) = 2,
-	CreateCharacter(CreateCharacter) = 4,
-	CharacterListResponse(CharacterListResponse) = 6,
-	CharacterCreateResponse(CharacterCreateResponse) = 7,
-	CharacterDeleteResponse(CharacterDeleteResponse) = 11,
-	SubjectGameMessage(SubjectGameMessage) = 12,
-	TransferToWorld(TransferToWorld) = 14,
-	BlueprintSaveResponse(BlueprintSaveResponse) = 21,
-	BlueprintLoadItemResponse(BlueprintLoadItemResponse) = 23,
-	AddFriendRequest(AddFriendRequest) = 27,
-	AddFriendResponse(AddFriendResponse) = 28,
-	GetFriendsListResponse(GetFriendsListResponse) = 30,
-	FriendUpdateNotify(FriendUpdateNotify) = 31,
-	GetIgnoreListResponse(GetIgnoreListResponse) = 34,
-	TeamInvite(TeamInvite) = 35,
-	MinimumChatModeResponse(MinimumChatModeResponse) = 57,
-	MinimumChatModeResponsePrivate(MinimumChatModeResponsePrivate) = 58,
-	ChatModerationString(ChatModerationString) = 59,
-	UpdateFreeTrialStatus(UpdateFreeTrialStatus) = 62,
+    LoadStaticZone(LoadStaticZone) = 2,
+    CreateCharacter(CreateCharacter) = 4,
+    CharacterListResponse(CharacterListResponse) = 6,
+    CharacterCreateResponse(CharacterCreateResponse) = 7,
+    CharacterDeleteResponse(CharacterDeleteResponse) = 11,
+    SubjectGameMessage(SubjectGameMessage) = 12,
+    TransferToWorld(TransferToWorld) = 14,
+    BlueprintSaveResponse(BlueprintSaveResponse) = 21,
+    BlueprintLoadItemResponse(BlueprintLoadItemResponse) = 23,
+    AddFriendRequest(AddFriendRequest) = 27,
+    AddFriendResponse(AddFriendResponse) = 28,
+    GetFriendsListResponse(GetFriendsListResponse) = 30,
+    FriendUpdateNotify(FriendUpdateNotify) = 31,
+    GetIgnoreListResponse(GetIgnoreListResponse) = 34,
+    TeamInvite(TeamInvite) = 35,
+    MinimumChatModeResponse(MinimumChatModeResponse) = 57,
+    MinimumChatModeResponsePrivate(MinimumChatModeResponsePrivate) = 58,
+    ChatModerationString(ChatModerationString) = 59,
+    UpdateFreeTrialStatus(UpdateFreeTrialStatus) = 62,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[repr(u32)]
 pub enum InstanceType {
-	Public,
-	Single,
-	Team,
-	Guild,
-	Match,
+    Public,
+    Single,
+    Team,
+    Guild,
+    Match,
 }
 
 /**
-	Tells the client to load a zone.
+    Tells the client to load a zone.
 
-	### Trigger
-	May be sent at any time. However, in a typical server instance architecture, this message will usually be sent as the first message directly after the client has validated itself with [`ClientValidation`](super::server::ClientValidation).
+    ### Trigger
+    May be sent at any time. However, in a typical server instance architecture, this message will usually be sent as the first message directly after the client has validated itself with [`ClientValidation`](super::server::ClientValidation).
 
-	### Handling
-	Load the zone specified in [`zone_id`](Self::zone_id), whatever that may entail for your client implementation.
+    ### Handling
+    Load the zone specified in [`zone_id`](Self::zone_id), whatever that may entail for your client implementation.
 
-	### Response
-	Respond with [`LevelLoadComplete`](super::server::LevelLoadComplete) once you're done loading.
+    ### Response
+    Respond with [`LevelLoadComplete`](super::server::LevelLoadComplete) once you're done loading.
 
-	### Notes
-	Server instances are usually statically assigned to host a "parallel universe" of a certain zone (world), which means that this message will be sent directly after client validation. However, other instance architectures are theoretically possible:
+    ### Notes
+    Server instances are usually statically assigned to host a "parallel universe" of a certain zone (world), which means that this message will be sent directly after client validation. However, other instance architectures are theoretically possible:
 
-	- Dynamic changing of the instance's zone, in which case additional [`LoadStaticZone`] messages could be sent (when the zone is changed).
+    - Dynamic changing of the instance's zone, in which case additional [`LoadStaticZone`] messages could be sent (when the zone is changed).
 
-	- Shared/overlapping instances, where the instance connection changes as the player moves around in the world, or where instances take over from others (e.g. in the event of a reboot), with mobs and all other state being carried over. In this case the client would be instructed to connect to the new instance via [`TransferToWorld`], but would not receive a [`LoadStaticZone`] afterwards. If done correctly, the player wouldn't even notice the transfer at all.
+    - Shared/overlapping instances, where the instance connection changes as the player moves around in the world, or where instances take over from others (e.g. in the event of a reboot), with mobs and all other state being carried over. In this case the client would be instructed to connect to the new instance via [`TransferToWorld`], but would not receive a [`LoadStaticZone`] afterwards. If done correctly, the player wouldn't even notice the transfer at all.
 
-	However, these are quite advanced architectures, and for now it is unlikely that any server project will actually pull these off.
+    However, these are quite advanced architectures, and for now it is unlikely that any server project will actually pull these off.
 */
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct LoadStaticZone {
-	/// ID of the zone to be loaded.
-	pub zone_id: ZoneId,
-	/// Checksum on the map on the server side. The original LU client will refuse to load any map where the client side checksum doesn't match the server checksum, to prevent inconsistencies and cheating.
-	pub map_checksum: u32,
-	// editor enabled and editor level, unused
-	#[padding=2]
-	/// The position of the player in the new world, likely used to be able to load the right part of the world.
-	pub player_position: Vector3,
-	/// The instance type of the zone being loaded.
-	pub instance_type: InstanceType,
+    /// ID of the zone to be loaded.
+    pub zone_id: ZoneId,
+    /// Checksum on the map on the server side. The original LU client will refuse to load any map where the client side checksum doesn't match the server checksum, to prevent inconsistencies and cheating.
+    pub map_checksum: u32,
+    // editor enabled and editor level, unused
+    #[padding = 2]
+    /// The position of the player in the new world, likely used to be able to load the right part of the world.
+    pub player_position: Vector3,
+    /// The instance type of the zone being loaded.
+    pub instance_type: InstanceType,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct CreateCharacter {
-	pub data: LuNameValue,
+    pub data: LuNameValue,
 }
 
 /**
-	Provides the list of characters of the client's account.
+    Provides the list of characters of the client's account.
 
-	### Trigger
-	Receipt of [`CharacterListRequest`](super::server::WorldMessage::CharacterListRequest). Also sent in response to [`CharacterCreateRequest`](super::server::CharacterCreateRequest) after [`CharacterCreateResponse`] if the creation is successful.
+    ### Trigger
+    Receipt of [`CharacterListRequest`](super::server::WorldMessage::CharacterListRequest). Also sent in response to [`CharacterCreateRequest`](super::server::CharacterCreateRequest) after [`CharacterCreateResponse`] if the creation is successful.
 
-	### Handling
-	Display the characters to the user for selection.
+    ### Handling
+    Display the characters to the user for selection.
 
-	### Response
-	None.
+    ### Response
+    None.
 
-	### Notes
-	The LU client can't handle sending more than four characters.
+    ### Notes
+    The LU client can't handle sending more than four characters.
 */
 #[derive(Debug, PartialEq)]
 pub struct CharacterListResponse {
-	/// Index into the list of characters below, specifying which character was used last.
-	pub selected_char: u8,
-	/// The list of characters.
-	pub chars: Vec<CharListChar>,
+    /// Index into the list of characters below, specifying which character was used last.
+    pub selected_char: u8,
+    /// The list of characters.
+    pub chars: Vec<CharListChar>,
 }
 
 impl<R: LERead> Deserialize<LE, R> for CharacterListResponse
-	where       u8: Deserialize<LE, R>,
-	  CharListChar: Deserialize<LE, R> {
-	fn deserialize(reader: &mut R) -> Res<Self>	{
-		let len: u8 = reader.read()?;
-		let selected_char = reader.read()?;
-		let mut chars = Vec::with_capacity(len as usize);
-		for _ in 0..len {
-			chars.push(reader.read()?);
-		}
-		Ok(Self { selected_char, chars } )
-	}
+where
+    u8: Deserialize<LE, R>,
+    CharListChar: Deserialize<LE, R>,
+{
+    fn deserialize(reader: &mut R) -> Res<Self> {
+        let len: u8 = reader.read()?;
+        let selected_char = reader.read()?;
+        let mut chars = Vec::with_capacity(len as usize);
+        for _ in 0..len {
+            chars.push(reader.read()?);
+        }
+        Ok(Self {
+            selected_char,
+            chars,
+        })
+    }
 }
 
 impl<'a, W: LEWrite> Serialize<LE, W> for &'a CharacterListResponse
-	where           u8: Serialize<LE, W>,
-	  &'a CharListChar: Serialize<LE, W> {
-	fn serialize(self, writer: &mut W) -> Res<()>	{
-		writer.write(self.chars.len() as u8)?;
-		writer.write(self.selected_char)?;
-		for chr in self.chars.iter() {
-			writer.write(chr)?;
-		}
-		Ok(())
-	}
+where
+    u8: Serialize<LE, W>,
+    &'a CharListChar: Serialize<LE, W>,
+{
+    fn serialize(self, writer: &mut W) -> Res<()> {
+        writer.write(self.chars.len() as u8)?;
+        writer.write(self.selected_char)?;
+        for chr in self.chars.iter() {
+            writer.write(chr)?;
+        }
+        Ok(())
+    }
 }
 
 /// A character from the [`CharacterListResponse`] message.
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct CharListChar {
-	pub obj_id: ObjId,
-	#[padding=4]
-	pub char_name: LuWString33,
-	pub pending_name: LuWString33,
-	pub requires_rename: bool,
-	pub is_free_trial: bool,
-	#[padding=10]
-	pub torso_color: u32,
-	#[padding=4]
-	pub legs_color: u32,
-	pub hair_style: u32,
-	pub hair_color: u32,
-	#[padding=8]
-	pub eyebrows_style: u32,
-	pub eyes_style: u32,
-	pub mouth_style: u32,
-	#[padding=4]
-	pub last_location: ZoneId,
-	#[padding=8]
-	pub equipped_items: LVec<u16, Lot>,
+    pub obj_id: ObjId,
+    #[padding = 4]
+    pub char_name: LuWString33,
+    pub pending_name: LuWString33,
+    pub requires_rename: bool,
+    pub is_free_trial: bool,
+    #[padding = 10]
+    pub torso_color: u32,
+    #[padding = 4]
+    pub legs_color: u32,
+    pub hair_style: u32,
+    pub hair_color: u32,
+    #[padding = 8]
+    pub eyebrows_style: u32,
+    pub eyes_style: u32,
+    pub mouth_style: u32,
+    #[padding = 4]
+    pub last_location: ZoneId,
+    #[padding = 8]
+    pub equipped_items: LVec<u16, Lot>,
 }
 
 /**
-	Reports the result of a character create request.
+    Reports the result of a character create request.
 
-	### Trigger
-	Receipt of [`CharacterCreateRequest`](super::server::CharacterCreateRequest).
+    ### Trigger
+    Receipt of [`CharacterCreateRequest`](super::server::CharacterCreateRequest).
 
-	### Handling
-	If the variant is not [`Success`](CharacterCreateResponse::Success), display an appropriate error message and let the user try again. If successful, wait for the updated [`CharacterListResponse`] packet to arrive and display the new character list.
+    ### Handling
+    If the variant is not [`Success`](CharacterCreateResponse::Success), display an appropriate error message and let the user try again. If successful, wait for the updated [`CharacterListResponse`] packet to arrive and display the new character list.
 
-	### Response
-	None.
+    ### Response
+    None.
 */
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[repr(u8)]
 pub enum CharacterCreateResponse {
-	/// The character has been successfully created.
-	Success,
-	/// Something went wrong during creation.
-	GeneralFailure,
-	/// The selected name is not allowed by the name moderation policy.
-	NameNotAllowed,
-	/// The ThreePartName is already in use.
-	PredefinedNameInUse,
-	/// The custom name is already in use.
-	CustomNameInUse,
+    /// The character has been successfully created.
+    Success,
+    /// Something went wrong during creation.
+    GeneralFailure,
+    /// The selected name is not allowed by the name moderation policy.
+    NameNotAllowed,
+    /// The ThreePartName is already in use.
+    PredefinedNameInUse,
+    /// The custom name is already in use.
+    CustomNameInUse,
 }
 
 /**
-	Reports the result of a character delete request.
+    Reports the result of a character delete request.
 
-	### Trigger
-	Receipt of [`CharacterDeleteRequest`](super::server::CharacterDeleteRequest).
+    ### Trigger
+    Receipt of [`CharacterDeleteRequest`](super::server::CharacterDeleteRequest).
 
-	### Handling
-	Delete the character locally if [`success`](Self::success) is `true`, else display an error message and keep the character.
+    ### Handling
+    Delete the character locally if [`success`](Self::success) is `true`, else display an error message and keep the character.
 
-	### Response
-	None.
+    ### Response
+    None.
 */
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct CharacterDeleteResponse {
-	/// Whether the deletion was successful.
-	pub success: bool,
+    /// Whether the deletion was successful.
+    pub success: bool,
 }
 
 /**
-	Tells the client to open a connection to another server instance.
+    Tells the client to open a connection to another server instance.
 
-	### Trigger
-	The server can send this at any time, but typically does when a launchpad or command is used to go to another world. Other reasons can include the instance shutting down, or exceeding its player limit.
+    ### Trigger
+    The server can send this at any time, but typically does when a launchpad or command is used to go to another world. Other reasons can include the instance shutting down, or exceeding its player limit.
 
-	### Response
-	Close the connection after the connection to the other instance has been established.
+    ### Response
+    Close the connection after the connection to the other instance has been established.
 */
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct TransferToWorld {
-	/// The host to connect to.
-	pub redirect_ip: LuString33,
-	/// The port to connect to.
-	pub redirect_port: u16,
-	/// If this is `true`, the original LU client displays a "Mythran dimensional shift succeeded" announcement.
-	pub is_maintenance_transfer: bool,
+    /// The host to connect to.
+    pub redirect_ip: LuString33,
+    /// The port to connect to.
+    pub redirect_port: u16,
+    /// If this is `true`, the original LU client displays a "Mythran dimensional shift succeeded" announcement.
+    pub is_maintenance_transfer: bool,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[repr(u32)]
 pub enum BlueprintSaveResponseType {
-	EverythingWorked,
-	SaveCancelled,
-	CantBeginTransaction,
-	SaveBlueprintFailed,
-	SaveUgobjectFailed,
-	CantEndTransaction,
-	SaveFilesFailed,
-	BadInput,
-	NotEnoughBricks,
-	InventoryFull,
-	ModelGenerationFailed,
-	PlacementFailed,
-	GmLevelInsufficient,
-	WaitForPreviousSave,
-	FindMatchesFailed,
+    EverythingWorked,
+    SaveCancelled,
+    CantBeginTransaction,
+    SaveBlueprintFailed,
+    SaveUgobjectFailed,
+    CantEndTransaction,
+    SaveFilesFailed,
+    BadInput,
+    NotEnoughBricks,
+    InventoryFull,
+    ModelGenerationFailed,
+    PlacementFailed,
+    GmLevelInsufficient,
+    WaitForPreviousSave,
+    FindMatchesFailed,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct BlueprintSaveResponseModel {
-	pub blueprint_id: ObjId,
-	pub lxfml_compressed: LVec<u32, u8>,
+    pub blueprint_id: ObjId,
+    pub lxfml_compressed: LVec<u32, u8>,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct BlueprintSaveResponse {
-	pub local_id: ObjId,
-	pub reason_code: BlueprintSaveResponseType,
-	pub models: LVec<u32, BlueprintSaveResponseModel>,
+    pub local_id: ObjId,
+    pub reason_code: BlueprintSaveResponseType,
+    pub models: LVec<u32, BlueprintSaveResponseModel>,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct BlueprintLoadItemResponse {
-	pub success: bool,
-	pub item_id: ObjId,
-	pub dest_item_id: ObjId,
+    pub success: bool,
+    pub item_id: ObjId,
+    pub dest_item_id: ObjId,
 }
 
 /**
-	Informs the client that another player has asked them to be their friend.
+    Informs the client that another player has asked them to be their friend.
 
-	### Trigger
-	Receipt of `ChatMessage::AddFriendRequest` (todo). Note that friend requests should be supported even if the recipient is on another instance, so a relay infrastructure like a chat server is necessary and needs to be accounted for.
+    ### Trigger
+    Receipt of `ChatMessage::AddFriendRequest` (todo). Note that friend requests should be supported even if the recipient is on another instance, so a relay infrastructure like a chat server is necessary and needs to be accounted for.
 
-	### Handling
-	Display a dialog to the player asking them whether to accept or deny the request.
+    ### Handling
+    Display a dialog to the player asking them whether to accept or deny the request.
 
-	### Response
-	Respond with [`AddFriendResponse`](crate::chat::server::AddFriendResponse) once the user has made their choice.
+    ### Response
+    Respond with [`AddFriendResponse`](crate::chat::server::AddFriendResponse) once the user has made their choice.
 */
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct AddFriendRequest {
-	/// Name of the requesting character.
-	pub sender_name: LuWString33,
-	/// Whether the request is asking to be best friends instead of just normal friends.
-	pub is_best_friend_request: bool,
+    /// Name of the requesting character.
+    pub sender_name: LuWString33,
+    /// Whether the request is asking to be best friends instead of just normal friends.
+    pub is_best_friend_request: bool,
 }
 
 #[derive(Debug, PartialEq)]
 #[repr(u8)]
 pub enum AddFriendResponseType {
-	Accepted {
-		is_online: bool,
-		sender_id: ObjId,
-		zone_id: ZoneId,
-		is_best_friend: bool,
-		is_free_trial: bool,
-	},
-	AlreadyFriend {
-		is_best_friend: bool,
-	},
-	InvalidCharacter,
-	GeneralError {
-		is_best_friend: bool,
-	},
-	YourFriendListFull,
-	TheirFriendListFull,
-	Declined,
-	Busy,
-	NotOnline,
-	WaitingApproval,
-	Mythran,
-	Cancelled,
-	FriendIsFreeTrial,
+    Accepted {
+        is_online: bool,
+        sender_id: ObjId,
+        zone_id: ZoneId,
+        is_best_friend: bool,
+        is_free_trial: bool,
+    },
+    AlreadyFriend {
+        is_best_friend: bool,
+    },
+    InvalidCharacter,
+    GeneralError {
+        is_best_friend: bool,
+    },
+    YourFriendListFull,
+    TheirFriendListFull,
+    Declined,
+    Busy,
+    NotOnline,
+    WaitingApproval,
+    Mythran,
+    Cancelled,
+    FriendIsFreeTrial,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct AddFriendResponse {
-	pub char_name: LuWString33,
-	pub response_type: AddFriendResponseType,
+    pub char_name: LuWString33,
+    pub response_type: AddFriendResponseType,
 }
 
 impl<R: Read> Deserialize<LE, R> for AddFriendResponse {
-	fn deserialize(reader: &mut R) -> Res<Self>	{
-		let disc: u8       = LERead::read(reader)?;
-		let is_online      = LERead::read(reader)?;
-		let char_name      = LERead::read(reader)?;
-		let sender_id      = LERead::read(reader)?;
-		let zone_id        = LERead::read(reader)?;
-		let is_best_friend = LERead::read(reader)?;
-		let is_free_trial  = LERead::read(reader)?;
-		Ok(Self { char_name, response_type:
-			match disc {
-				0  => AddFriendResponseType::Accepted { is_online, sender_id, zone_id, is_best_friend, is_free_trial },
-				1  => AddFriendResponseType::AlreadyFriend { is_best_friend },
-				2  => AddFriendResponseType::InvalidCharacter,
-				3  => AddFriendResponseType::GeneralError { is_best_friend },
-				4  => AddFriendResponseType::YourFriendListFull,
-				5  => AddFriendResponseType::TheirFriendListFull,
-				6  => AddFriendResponseType::Declined,
-				7  => AddFriendResponseType::Busy,
-				8  => AddFriendResponseType::NotOnline,
-				9  => AddFriendResponseType::WaitingApproval,
-				10 => AddFriendResponseType::Mythran,
-				11 => AddFriendResponseType::Cancelled,
-				12 => AddFriendResponseType::FriendIsFreeTrial,
-				_  => { return Err(Error::new(InvalidData, "invalid discriminant for AddFriendResponseType")) }
-			}
-		})
-	}
+    fn deserialize(reader: &mut R) -> Res<Self> {
+        let disc: u8 = LERead::read(reader)?;
+        let is_online = LERead::read(reader)?;
+        let char_name = LERead::read(reader)?;
+        let sender_id = LERead::read(reader)?;
+        let zone_id = LERead::read(reader)?;
+        let is_best_friend = LERead::read(reader)?;
+        let is_free_trial = LERead::read(reader)?;
+        Ok(Self {
+            char_name,
+            response_type: match disc {
+                0 => AddFriendResponseType::Accepted {
+                    is_online,
+                    sender_id,
+                    zone_id,
+                    is_best_friend,
+                    is_free_trial,
+                },
+                1 => AddFriendResponseType::AlreadyFriend { is_best_friend },
+                2 => AddFriendResponseType::InvalidCharacter,
+                3 => AddFriendResponseType::GeneralError { is_best_friend },
+                4 => AddFriendResponseType::YourFriendListFull,
+                5 => AddFriendResponseType::TheirFriendListFull,
+                6 => AddFriendResponseType::Declined,
+                7 => AddFriendResponseType::Busy,
+                8 => AddFriendResponseType::NotOnline,
+                9 => AddFriendResponseType::WaitingApproval,
+                10 => AddFriendResponseType::Mythran,
+                11 => AddFriendResponseType::Cancelled,
+                12 => AddFriendResponseType::FriendIsFreeTrial,
+                _ => {
+                    return Err(Error::new(
+                        InvalidData,
+                        "invalid discriminant for AddFriendResponseType",
+                    ))
+                }
+            },
+        })
+    }
 }
 
 impl<'a, W: Write> Serialize<LE, W> for &'a AddFriendResponse {
-	fn serialize(self, writer: &mut W) -> Res<()>	{
-		let disc = unsafe { *(&self.response_type as *const AddFriendResponseType as *const u8) };
-		LEWrite::write(writer, disc)?;
-		let mut is_online_x = &false;
-		let mut sender_id_x = &0;
-		let mut zone_id_x = &ZoneId { map_id: 0, instance_id: 0, clone_id: 0 };
-		let mut is_best_friend_x = &false;
-		let mut is_free_trial_x = &false;
-		match &self.response_type {
-			AddFriendResponseType::Accepted { is_online, sender_id, zone_id, is_best_friend, is_free_trial } => {
-				is_online_x = is_online;
-				sender_id_x = sender_id;
-				zone_id_x = zone_id;
-				is_best_friend_x = is_best_friend;
-				is_free_trial_x = is_free_trial;
-			}
-			AddFriendResponseType::AlreadyFriend { is_best_friend } => {
-				is_best_friend_x = is_best_friend;
-			}
-			AddFriendResponseType::GeneralError { is_best_friend } => {
-				is_best_friend_x = is_best_friend;
-			}
-			_ => {},
-		}
-		LEWrite::write(writer, is_online_x)?;
-		LEWrite::write(writer, &self.char_name)?;
-		LEWrite::write(writer, sender_id_x)?;
-		LEWrite::write(writer, zone_id_x)?;
-		LEWrite::write(writer, is_best_friend_x)?;
-		LEWrite::write(writer, is_free_trial_x)?;
-		Ok(())
-	}
+    fn serialize(self, writer: &mut W) -> Res<()> {
+        let disc = unsafe { *(&self.response_type as *const AddFriendResponseType as *const u8) };
+        LEWrite::write(writer, disc)?;
+        let mut is_online_x = &false;
+        let mut sender_id_x = &0;
+        let mut zone_id_x = &ZoneId {
+            map_id: 0,
+            instance_id: 0,
+            clone_id: 0,
+        };
+        let mut is_best_friend_x = &false;
+        let mut is_free_trial_x = &false;
+        match &self.response_type {
+            AddFriendResponseType::Accepted {
+                is_online,
+                sender_id,
+                zone_id,
+                is_best_friend,
+                is_free_trial,
+            } => {
+                is_online_x = is_online;
+                sender_id_x = sender_id;
+                zone_id_x = zone_id;
+                is_best_friend_x = is_best_friend;
+                is_free_trial_x = is_free_trial;
+            }
+            AddFriendResponseType::AlreadyFriend { is_best_friend } => {
+                is_best_friend_x = is_best_friend;
+            }
+            AddFriendResponseType::GeneralError { is_best_friend } => {
+                is_best_friend_x = is_best_friend;
+            }
+            _ => {}
+        }
+        LEWrite::write(writer, is_online_x)?;
+        LEWrite::write(writer, &self.char_name)?;
+        LEWrite::write(writer, sender_id_x)?;
+        LEWrite::write(writer, zone_id_x)?;
+        LEWrite::write(writer, is_best_friend_x)?;
+        LEWrite::write(writer, is_free_trial_x)?;
+        Ok(())
+    }
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
-#[trailing_padding=6]
+#[trailing_padding = 6]
 pub struct FriendState {
-	pub is_online: bool,
-	pub is_best_friend: bool,
-	pub is_free_trial: bool,
-	#[padding=5]
-	pub location: ZoneId,
-	pub object_id: ObjId,
-	pub char_name: LuWString33,
+    pub is_online: bool,
+    pub is_best_friend: bool,
+    pub is_free_trial: bool,
+    #[padding = 5]
+    pub location: ZoneId,
+    pub object_id: ObjId,
+    pub char_name: LuWString33,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[repr(u8)]
-#[post_disc_padding=2]
+#[post_disc_padding = 2]
 pub enum GetFriendsListResponse {
-	Ok(LVec<u16, FriendState>),
-	GeneralError,
+    Ok(LVec<u16, FriendState>),
+    GeneralError,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[repr(u8)]
 pub enum FriendUpdateType {
-	Logout,
-	Login,
-	Transfer,
-	FreeTrialChange,
+    Logout,
+    Login,
+    Transfer,
+    FreeTrialChange,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct FriendUpdateNotify {
-	pub update_type: FriendUpdateType,
-	pub char_name: LuWString33,
-	pub zone_id: ZoneId,
-	pub is_best_friend: bool,
-	pub is_free_trial: bool,
+    pub update_type: FriendUpdateType,
+    pub char_name: LuWString33,
+    pub zone_id: ZoneId,
+    pub is_best_friend: bool,
+    pub is_free_trial: bool,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
-#[trailing_padding=6]
+#[trailing_padding = 6]
 pub struct IgnoreState {
-	pub object_id: ObjId,
-	pub char_name: LuWString33,
+    pub object_id: ObjId,
+    pub char_name: LuWString33,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[repr(u8)]
-#[post_disc_padding=2]
+#[post_disc_padding = 2]
 pub enum GetIgnoreListResponse {
-	Ok(LVec<u16, IgnoreState>),
-	GeneralError,
+    Ok(LVec<u16, IgnoreState>),
+    GeneralError,
 }
 
 /**
-	Informs the client that another player has asked them to be their friend.
+    Informs the client that another player has asked them to be their friend.
 
-	### Trigger
-	Receipt of `ChatMessage::TeamInvite` (todo). Note that team invites should be supported even if the recipient is on another instance, so a relay infrastructure like a chat server is necessary and needs to be accounted for.
+    ### Trigger
+    Receipt of `ChatMessage::TeamInvite` (todo). Note that team invites should be supported even if the recipient is on another instance, so a relay infrastructure like a chat server is necessary and needs to be accounted for.
 
-	### Handling
-	Display a dialog to the player asking them whether to accept or deny the request.
+    ### Handling
+    Display a dialog to the player asking them whether to accept or deny the request.
 
-	### Response
-	Respond with [`TeamInviteResponse`](crate::chat::server::TeamInviteResponse) once the user has made their choice.
+    ### Response
+    Respond with [`TeamInviteResponse`](crate::chat::server::TeamInviteResponse) once the user has made their choice.
 */
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct TeamInvite {
-	/// Name of the requesting character.
-	pub sender_name: LuWString33,
-	/// Object ID of the requesting character.
-	pub sender_id: ObjId,
+    /// Name of the requesting character.
+    pub sender_name: LuWString33,
+    /// Object ID of the requesting character.
+    pub sender_id: ObjId,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct MinimumChatModeResponse {
-	pub chat_mode: u8, // todo: type?
-	pub chat_channel: ChatChannel,
+    pub chat_mode: u8, // todo: type?
+    pub chat_channel: ChatChannel,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct MinimumChatModeResponsePrivate {
-	pub chat_mode: u8, // todo: type?
-	pub chat_channel: ChatChannel,
-	pub recipient_name: LuWString33,
-	pub recipient_gm_level: u8,
+    pub chat_mode: u8, // todo: type?
+    pub chat_channel: ChatChannel,
+    pub recipient_name: LuWString33,
+    pub recipient_gm_level: u8,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize, PartialEq, Serialize)]
 pub struct ModerationSpan {
-	pub start_index: u8,
-	pub length: u8,
+    pub start_index: u8,
+    pub length: u8,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct ChatModerationString {
-	//#[padding=2]
-	pub request_id: u8,
-	pub chat_mode: u8, // todo: type
-	pub whisper_name: LuWString42,
-	pub spans: Vec<ModerationSpan>,
+    //#[padding=2]
+    pub request_id: u8,
+    pub chat_mode: u8, // todo: type
+    pub whisper_name: LuWString42,
+    pub spans: Vec<ModerationSpan>,
 }
 
-impl<R: Read+LERead> Deserialize<LE, R> for ChatModerationString {
-	fn deserialize(reader: &mut R) -> Res<Self>	{
-		let _string_okay: bool = LERead::read(reader)?;
-		let _source_id: u16 = LERead::read(reader)?; // unused
-		let request_id = LERead::read(reader)?;
-		let chat_mode = LERead::read(reader)?;
-		let whisper_name = LERead::read(reader)?;
-		let mut spans = vec![];
-		let mut i = 0;
-		loop {
-			if i > 63 {
-				break;
-			}
-			let start_index = LERead::read(reader)?;
-			let length = LERead::read(reader)?;
-			if length != 0 {
-				spans.push(ModerationSpan { start_index, length });
-			}
-			i += 1;
-		}
-		Ok(Self { request_id, chat_mode, whisper_name, spans })
-	}
+impl<R: Read + LERead> Deserialize<LE, R> for ChatModerationString {
+    fn deserialize(reader: &mut R) -> Res<Self> {
+        let _string_okay: bool = LERead::read(reader)?;
+        let _source_id: u16 = LERead::read(reader)?; // unused
+        let request_id = LERead::read(reader)?;
+        let chat_mode = LERead::read(reader)?;
+        let whisper_name = LERead::read(reader)?;
+        let mut spans = vec![];
+        let mut i = 0;
+        loop {
+            if i > 63 {
+                break;
+            }
+            let start_index = LERead::read(reader)?;
+            let length = LERead::read(reader)?;
+            if length != 0 {
+                spans.push(ModerationSpan {
+                    start_index,
+                    length,
+                });
+            }
+            i += 1;
+        }
+        Ok(Self {
+            request_id,
+            chat_mode,
+            whisper_name,
+            spans,
+        })
+    }
 }
 
-impl<'a, W: Write+LEWrite> Serialize<LE, W> for &'a ChatModerationString {
-	fn serialize(self, writer: &mut W) -> Res<()>	{
-		LEWrite::write(writer, self.spans.is_empty())?;
-		LEWrite::write(writer, 0u16)?;
-		LEWrite::write(writer, self.request_id)?;
-		LEWrite::write(writer, self.chat_mode)?;
-		LEWrite::write(writer, &self.whisper_name)?;
-		if self.spans.len() > 64 {
-			return Err(Error::new(InvalidData, "spans longer than 64"));
-		}
-		for span in &self.spans {
-			LEWrite::write(writer, span.start_index)?;
-			LEWrite::write(writer, span.length)?;
-		}
-		for _ in self.spans.len()..64 {
-			Write::write(writer, &[0; 2])?;
-		}
-		Ok(())
-	}
+impl<'a, W: Write + LEWrite> Serialize<LE, W> for &'a ChatModerationString {
+    fn serialize(self, writer: &mut W) -> Res<()> {
+        LEWrite::write(writer, self.spans.is_empty())?;
+        LEWrite::write(writer, 0u16)?;
+        LEWrite::write(writer, self.request_id)?;
+        LEWrite::write(writer, self.chat_mode)?;
+        LEWrite::write(writer, &self.whisper_name)?;
+        if self.spans.len() > 64 {
+            return Err(Error::new(InvalidData, "spans longer than 64"));
+        }
+        for span in &self.spans {
+            LEWrite::write(writer, span.start_index)?;
+            LEWrite::write(writer, span.length)?;
+        }
+        for _ in self.spans.len()..64 {
+            Write::write(writer, &[0; 2])?;
+        }
+        Ok(())
+    }
 }
 
 /**
-	Notifies the client that its free trial status has changed.
+    Notifies the client that its free trial status has changed.
 
-	### Trigger
-	Sent by the server when the status changes.
+    ### Trigger
+    Sent by the server when the status changes.
 
-	### Handling
-	Display appropriate UI, celebration, etc.
+    ### Handling
+    Display appropriate UI, celebration, etc.
 
-	### Response
-	None.
+    ### Response
+    None.
 */
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct UpdateFreeTrialStatus {
-	/// Whether the player is on free trial.
-	pub is_free_trial: bool,
+    /// Whether the player is on free trial.
+    pub is_free_trial: bool,
 }

--- a/src/world/gm/client/mod.rs
+++ b/src/world/gm/client/mod.rs
@@ -5,1690 +5,1696 @@ use lu_packets_derive::{FromVariants, GameMessage, GmParam, VariantTests};
 
 use crate::common::{ObjId, OBJID_EMPTY};
 
-use crate::world::{CloneId, CLONE_ID_INVALID, Lot, LOT_NULL, LuNameValue, MapId, MAP_ID_INVALID, Quaternion, Vector3, ZoneId};
-use crate::world::amf3::Amf3;
-pub use super::{EquipInventory, InventoryType, KillType, UnEquipInventory, MissionState, PetNotificationType, MoveItemInInventory, MoveInventoryBatch, RemoveSkill, SetIgnoreProjectileCollision};
+pub use super::{
+    EquipInventory, InventoryType, KillType, MissionState, MoveInventoryBatch, MoveItemInInventory,
+    PetNotificationType, RemoveSkill, SetIgnoreProjectileCollision, UnEquipInventory,
+};
 use super::{GmString, GmWString};
+use crate::world::amf3::Amf3;
+use crate::world::{
+    CloneId, Lot, LuNameValue, MapId, Quaternion, Vector3, ZoneId, CLONE_ID_INVALID, LOT_NULL,
+    MAP_ID_INVALID,
+};
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct SubjectGameMessage {
-	pub subject_id: ObjId,
-	pub message: GameMessage,
+    pub subject_id: ObjId,
+    pub message: GameMessage,
 }
 
 #[derive(Debug, Deserialize, FromVariants, PartialEq, Serialize, VariantTests)]
 #[repr(u16)]
 pub enum GameMessage {
-	Teleport(Teleport) = 19,
-	DropClientLoot(DropClientLoot) = 30,
-	Die(Die) = 37,
-	PreloadAnimation(PreloadAnimation) = 42,
-	PlayAnimation(PlayAnimation) = 43,
-	SetName(SetName) = 72,
-	AddSkill(AddSkill) = 127,
-	RemoveSkill(RemoveSkill) = 128,
-	SetCurrency(SetCurrency) = 133,
-	TeamPickupItem(TeamPickupItem) = 140,
-	PlayFxEffect(PlayFxEffect) = 154,
-	StopFxEffect(StopFxEffect) = 155,
-	Resurrect(Resurrect) = 160,
-	SetStunned(SetStunned) = 198,
-	SetStunImmunity(SetStunImmunity) = 200,
-	Knockback(Knockback) = 202,
-	EnableRebuild(EnableRebuild) = 213,
-	MoveItemInInventory(MoveItemInInventory) = 224,
-	AddItemToInventoryClientSync(AddItemToInventoryClientSync) = 227,
-	EquipInventory(EquipInventory) = 231,
-	UnEquipInventory(UnEquipInventory) = 233,
-	OfferMission(OfferMission) = 248,
-	NotifyMission(NotifyMission) = 254,
-	RebuildNotifyState(RebuildNotifyState) = 336,
-	ToggleInteractionUpdates(ToggleInteractionUpdates) = 356,
-	TerminateInteraction(TerminateInteraction) = 357,
-	VendorOpenWindow = 369,
-	EmotePlayed(EmotePlayed) = 371,
-	TeamSetOffWorldFlag(TeamSetOffWorldFlag) = 383,
-	SetInventorySize(SetInventorySize) = 389,
-	ActivityEnter = 405,
-	ActivityExit = 406,
-	ActivityStart = 407,
-	ActivityStop(ActivityStop) = 408,
-	CancelMission(CancelMission) = 418,
-	ResetMissions(ResetMissions) = 419,
-	NotifyClientShootingGalleryScore(NotifyClientShootingGalleryScore) = 425,
-	SetUserCtrlCompPause(SetUserCtrlCompPause) = 466,
-	NotifyClientFlagChange(NotifyClientFlagChange) = 472,
-	Help(Help) = 475,
-	VendorTransactionResult(VendorTransactionResult) = 476,
-	HasBeenCollectedByClient(HasBeenCollectedByClient) = 487,
-	PlayerReady = 509,
-	TransferToZone(TransferToZone) = 516,
-	TransferToZoneCheckedIm(TransferToZoneCheckedIm) = 517,
-	InvalidZoneTransferList(InvalidZoneTransferList) = 519,
-	TransferToLastNonInstance(TransferToLastNonInstance) = 527,
-	DisplayMessageBox(DisplayMessageBox) = 529,
-	Smash(Smash) = 537,
-	UnSmash(UnSmash) = 538,
-	SetGravityScale(SetGravityScale) = 541,
-	PlaceModelResponse(PlaceModelResponse) = 547,
-	SetJetPackMode(SetJetPackMode) = 561,
-	RegisterPetId(RegisterPetId) = 565,
-	RegisterPetDbId(RegisterPetDbId) = 566,
-	ShowActivityCountdown(ShowActivityCountdown) = 568,
-	DisplayTooltip(DisplayTooltip) = 569,
-	StartActivityTime(StartActivityTime) = 576,
-	ActivityPause(ActivityPause) = 602,
-	UseItemResult(UseItemResult) = 607,
-	PetResponse(PetResponse) = 641,
-	SendActivitySummaryLeaderboardData(SendActivitySummaryLeaderboardData) = 649,
-	ClientNotifyPet(ClientNotifyPet) = 659,
-	NotifyPetTamingMinigame(NotifyPetTamingMinigame) = 661,
-	PetTamingTryBuildResult(PetTamingTryBuildResult) = 668,
-	NotifyTamingModelLoadedOnServer = 674,
-	AddPetToPlayer(AddPetToPlayer) = 681,
-	SetPetName(SetPetName) = 684,
-	PetNameChanged(PetNameChanged) = 686,
-	ShowPetActionButton(ShowPetActionButton) = 692,
-	SetEmoteLockState(SetEmoteLockState) = 693,
-	UseItemRequirementsResponse(UseItemRequirementsResponse) = 703,
-	PlayEmbeddedEffectOnAllClientsNearObject(PlayEmbeddedEffectOnAllClientsNearObject) = 713,
-	NotifyClientZoneObject(NotifyClientZoneObject) = 737,
-	UpdateReputation(UpdateReputation) = 746,
-	PropertyRentalResponse(PropertyRentalResponse) = 750,
-	PlatformResync(PlatformResync) = 761,
-	PlayCinematic(PlayCinematic) = 762,
-	EndCinematic(EndCinematic) = 763,
-	ScriptNetworkVarUpdate(ScriptNetworkVarUpdate) = 781,
-	BroadcastTextToChatbox(BroadcastTextToChatbox) = 858,
-	OpenPropertyVendor = 861,
-	ServerTradeInvite(ServerTradeInvite) = 870,
-	ServerTradeInitialReply(ServerTradeInitialReply) = 873,
-	ServerTradeFinalReply(ServerTradeFinalReply) = 874,
-	ServerTradeAccept(ServerTradeAccept) = 884,
-	GetLastCustomBuild(GetLastCustomBuild) = 891,
-	SetIgnoreProjectileCollision(SetIgnoreProjectileCollision) = 903,
-	OrientToObject(OrientToObject) = 905,
-	OrientToPosition(OrientToPosition) = 906,
-	OrientToAngle(OrientToAngle) = 907,
-	PropertyModerationStatusUpdate(PropertyModerationStatusUpdate) = 917,
-	RequestClientBounce(RequestClientBounce) = 934,
-	BouncerActiveStatus(BouncerActiveStatus) = 942,
-	MoveInventoryBatch(MoveInventoryBatch) = 957,
-	ObjectActivatedClient(ObjectActivatedClient) = 980,
-	NotifyClientObject(NotifyClientObject) = 1042,
-	DisplayZoneSummary(DisplayZoneSummary) = 1043,
-	ModifyPlayerZoneStatistic(ModifyPlayerZoneStatistic) = 1046,
-	StartArrangingWithItem(StartArrangingWithItem) = 1061,
-	FinishArrangingWithItem(FinishArrangingWithItem) = 1062,
-	SetBuildModeConfirmed(SetBuildModeConfirmed) = 1073,
-	BuildModeNotificationReport(BuildModeNotificationReport) = 1075,
-	SetModelToBuild(SetModelToBuild) = 1077,
-	SpawnModelBricks(SpawnModelBricks) = 1078,
-	NotifyClientFailedPrecondition(NotifyClientFailedPrecondition) = 1081,
-	ModuleAssemblyDbDataForClient(ModuleAssemblyDbDataForClient) = 1131,
-	EchoSyncSkill(EchoSyncSkill) = 1144,
-	DoClientProjectileImpact(DoClientProjectileImpact) = 1151,
-	SetPlayerAllowedRespawn(SetPlayerAllowedRespawn) = 1165,
-	UiMessageServerToSingleClient(UiMessageServerToSingleClient) = 1184,
-	UncastSkill(UncastSkill) = 1206,
-	FireEventClientSide(FireEventClientSide) = 1213,
-	ChangeObjectWorldState(ChangeObjectWorldState) = 1223,
-	VehicleLockInput(VehicleLockInput) = 1230,
-	VehicleUnlockInput(VehicleUnlockInput) = 1231,
-	RacingResetPlayerToLastReset(RacingResetPlayerToLastReset) = 1252,
-	RacingSetPlayerResetInfo(RacingSetPlayerResetInfo) = 1254,
-	LockNodeRotation(LockNodeRotation) = 1260,
-	NotifyVehicleOfRacingObject(NotifyVehicleOfRacingObject) = 1276,
-	PlayerReachedRespawnCheckpoint(PlayerReachedRespawnCheckpoint) = 1296,
-	HandleUgcEquipPostDeleteBasedOnEditMode(HandleUgcEquipPostDeleteBasedOnEditMode) = 1300,
-	HandleUgcEquipPreCreateBasedOnEditMode(HandleUgcEquipPreCreateBasedOnEditMode) = 1301,
-	MatchResponse(MatchResponse) = 1309,
-	MatchUpdate(MatchUpdate) = 1310,
-	ChangeIdleFlags(ChangeIdleFlags) = 1338,
-	VehicleAddPassiveBoostAction = 1340,
-	VehicleRemovePassiveBoostAction = 1341,
-	NotifyRacingClient(NotifyRacingClient) = 1390,
-	RacingPlayerLoaded(RacingPlayerLoaded) = 1392,
-	SetStatusImmunity(SetStatusImmunity) = 1435,
-	SetPetNameModerated(SetPetNameModerated) = 1448,
-	CancelSkillCast = 1451,
-	ModifyLegoScore(ModifyLegoScore) = 1459,
-	RestoreToPostLoadStats = 1468,
-	SetRailMovement(SetRailMovement) = 1471,
-	StartRailMovement(StartRailMovement) = 1472,
-	NotifyRailActivatorStateChange(NotifyRailActivatorStateChange) = 1478,
-	NotifyRewardMailed(NotifyRewardMailed) = 1480,
-	UpdatePlayerStatistic(UpdatePlayerStatistic) = 1481,
-	RequeryPropertyModels = 1491,
-	NotifyNotEnoughInvSpace(NotifyNotEnoughInvSpace) = 1516,
-	NotifyPropertyOfEditMode(NotifyPropertyOfEditMode) = 1546,
-	PropertyEntranceBegin = 1553,
-	TeamSetLeader(TeamSetLeader) = 1557,
-	TeamGetStatusResponse(TeamGetStatusResponse) = 1559,
-	TeamAddPlayer(TeamAddPlayer) = 1562,
-	TeamRemovePlayer(TeamRemovePlayer) = 1563,
-	SetResurrectRestoreValues(SetResurrectRestoreValues) = 1591,
-	SetPropertyModerationStatus(SetPropertyModerationStatus) = 1594,
-	UpdatePropertyModelCount(UpdatePropertyModelCount) = 1595,
-	VehicleStopBoost(VehicleStopBoost) = 1617,
-	StartCelebrationEffect(StartCelebrationEffect) = 1618,
-	SetLocalTeam(SetLocalTeam) = 1636,
-	ServerDoneLoadingAllObjects = 1642,
-	ResponseMoveItemBetweenInventoryTypes(ResponseMoveItemBetweenInventoryTypes) = 1667,
-	PlayerSetCameraCyclingMode(PlayerSetCameraCyclingMode) = 1676,
-	SetMountInventoryId(SetMountInventoryId) = 1726,
-	NotifyLevelRewards(NotifyLevelRewards) = 1735,
-	ClientCancelMoveSkill = 1747,
-	MarkInventoryItemAsActive(MarkInventoryItemAsActive) = 1767,
+    Teleport(Teleport) = 19,
+    DropClientLoot(DropClientLoot) = 30,
+    Die(Die) = 37,
+    PreloadAnimation(PreloadAnimation) = 42,
+    PlayAnimation(PlayAnimation) = 43,
+    SetName(SetName) = 72,
+    AddSkill(AddSkill) = 127,
+    RemoveSkill(RemoveSkill) = 128,
+    SetCurrency(SetCurrency) = 133,
+    TeamPickupItem(TeamPickupItem) = 140,
+    PlayFxEffect(PlayFxEffect) = 154,
+    StopFxEffect(StopFxEffect) = 155,
+    Resurrect(Resurrect) = 160,
+    SetStunned(SetStunned) = 198,
+    SetStunImmunity(SetStunImmunity) = 200,
+    Knockback(Knockback) = 202,
+    EnableRebuild(EnableRebuild) = 213,
+    MoveItemInInventory(MoveItemInInventory) = 224,
+    AddItemToInventoryClientSync(AddItemToInventoryClientSync) = 227,
+    EquipInventory(EquipInventory) = 231,
+    UnEquipInventory(UnEquipInventory) = 233,
+    OfferMission(OfferMission) = 248,
+    NotifyMission(NotifyMission) = 254,
+    RebuildNotifyState(RebuildNotifyState) = 336,
+    ToggleInteractionUpdates(ToggleInteractionUpdates) = 356,
+    TerminateInteraction(TerminateInteraction) = 357,
+    VendorOpenWindow = 369,
+    EmotePlayed(EmotePlayed) = 371,
+    TeamSetOffWorldFlag(TeamSetOffWorldFlag) = 383,
+    SetInventorySize(SetInventorySize) = 389,
+    ActivityEnter = 405,
+    ActivityExit = 406,
+    ActivityStart = 407,
+    ActivityStop(ActivityStop) = 408,
+    CancelMission(CancelMission) = 418,
+    ResetMissions(ResetMissions) = 419,
+    NotifyClientShootingGalleryScore(NotifyClientShootingGalleryScore) = 425,
+    SetUserCtrlCompPause(SetUserCtrlCompPause) = 466,
+    NotifyClientFlagChange(NotifyClientFlagChange) = 472,
+    Help(Help) = 475,
+    VendorTransactionResult(VendorTransactionResult) = 476,
+    HasBeenCollectedByClient(HasBeenCollectedByClient) = 487,
+    PlayerReady = 509,
+    TransferToZone(TransferToZone) = 516,
+    TransferToZoneCheckedIm(TransferToZoneCheckedIm) = 517,
+    InvalidZoneTransferList(InvalidZoneTransferList) = 519,
+    TransferToLastNonInstance(TransferToLastNonInstance) = 527,
+    DisplayMessageBox(DisplayMessageBox) = 529,
+    Smash(Smash) = 537,
+    UnSmash(UnSmash) = 538,
+    SetGravityScale(SetGravityScale) = 541,
+    PlaceModelResponse(PlaceModelResponse) = 547,
+    SetJetPackMode(SetJetPackMode) = 561,
+    RegisterPetId(RegisterPetId) = 565,
+    RegisterPetDbId(RegisterPetDbId) = 566,
+    ShowActivityCountdown(ShowActivityCountdown) = 568,
+    DisplayTooltip(DisplayTooltip) = 569,
+    StartActivityTime(StartActivityTime) = 576,
+    ActivityPause(ActivityPause) = 602,
+    UseItemResult(UseItemResult) = 607,
+    PetResponse(PetResponse) = 641,
+    SendActivitySummaryLeaderboardData(SendActivitySummaryLeaderboardData) = 649,
+    ClientNotifyPet(ClientNotifyPet) = 659,
+    NotifyPetTamingMinigame(NotifyPetTamingMinigame) = 661,
+    PetTamingTryBuildResult(PetTamingTryBuildResult) = 668,
+    NotifyTamingModelLoadedOnServer = 674,
+    AddPetToPlayer(AddPetToPlayer) = 681,
+    SetPetName(SetPetName) = 684,
+    PetNameChanged(PetNameChanged) = 686,
+    ShowPetActionButton(ShowPetActionButton) = 692,
+    SetEmoteLockState(SetEmoteLockState) = 693,
+    UseItemRequirementsResponse(UseItemRequirementsResponse) = 703,
+    PlayEmbeddedEffectOnAllClientsNearObject(PlayEmbeddedEffectOnAllClientsNearObject) = 713,
+    NotifyClientZoneObject(NotifyClientZoneObject) = 737,
+    UpdateReputation(UpdateReputation) = 746,
+    PropertyRentalResponse(PropertyRentalResponse) = 750,
+    PlatformResync(PlatformResync) = 761,
+    PlayCinematic(PlayCinematic) = 762,
+    EndCinematic(EndCinematic) = 763,
+    ScriptNetworkVarUpdate(ScriptNetworkVarUpdate) = 781,
+    BroadcastTextToChatbox(BroadcastTextToChatbox) = 858,
+    OpenPropertyVendor = 861,
+    ServerTradeInvite(ServerTradeInvite) = 870,
+    ServerTradeInitialReply(ServerTradeInitialReply) = 873,
+    ServerTradeFinalReply(ServerTradeFinalReply) = 874,
+    ServerTradeAccept(ServerTradeAccept) = 884,
+    GetLastCustomBuild(GetLastCustomBuild) = 891,
+    SetIgnoreProjectileCollision(SetIgnoreProjectileCollision) = 903,
+    OrientToObject(OrientToObject) = 905,
+    OrientToPosition(OrientToPosition) = 906,
+    OrientToAngle(OrientToAngle) = 907,
+    PropertyModerationStatusUpdate(PropertyModerationStatusUpdate) = 917,
+    RequestClientBounce(RequestClientBounce) = 934,
+    BouncerActiveStatus(BouncerActiveStatus) = 942,
+    MoveInventoryBatch(MoveInventoryBatch) = 957,
+    ObjectActivatedClient(ObjectActivatedClient) = 980,
+    NotifyClientObject(NotifyClientObject) = 1042,
+    DisplayZoneSummary(DisplayZoneSummary) = 1043,
+    ModifyPlayerZoneStatistic(ModifyPlayerZoneStatistic) = 1046,
+    StartArrangingWithItem(StartArrangingWithItem) = 1061,
+    FinishArrangingWithItem(FinishArrangingWithItem) = 1062,
+    SetBuildModeConfirmed(SetBuildModeConfirmed) = 1073,
+    BuildModeNotificationReport(BuildModeNotificationReport) = 1075,
+    SetModelToBuild(SetModelToBuild) = 1077,
+    SpawnModelBricks(SpawnModelBricks) = 1078,
+    NotifyClientFailedPrecondition(NotifyClientFailedPrecondition) = 1081,
+    ModuleAssemblyDbDataForClient(ModuleAssemblyDbDataForClient) = 1131,
+    EchoSyncSkill(EchoSyncSkill) = 1144,
+    DoClientProjectileImpact(DoClientProjectileImpact) = 1151,
+    SetPlayerAllowedRespawn(SetPlayerAllowedRespawn) = 1165,
+    UiMessageServerToSingleClient(UiMessageServerToSingleClient) = 1184,
+    UncastSkill(UncastSkill) = 1206,
+    FireEventClientSide(FireEventClientSide) = 1213,
+    ChangeObjectWorldState(ChangeObjectWorldState) = 1223,
+    VehicleLockInput(VehicleLockInput) = 1230,
+    VehicleUnlockInput(VehicleUnlockInput) = 1231,
+    RacingResetPlayerToLastReset(RacingResetPlayerToLastReset) = 1252,
+    RacingSetPlayerResetInfo(RacingSetPlayerResetInfo) = 1254,
+    LockNodeRotation(LockNodeRotation) = 1260,
+    NotifyVehicleOfRacingObject(NotifyVehicleOfRacingObject) = 1276,
+    PlayerReachedRespawnCheckpoint(PlayerReachedRespawnCheckpoint) = 1296,
+    HandleUgcEquipPostDeleteBasedOnEditMode(HandleUgcEquipPostDeleteBasedOnEditMode) = 1300,
+    HandleUgcEquipPreCreateBasedOnEditMode(HandleUgcEquipPreCreateBasedOnEditMode) = 1301,
+    MatchResponse(MatchResponse) = 1309,
+    MatchUpdate(MatchUpdate) = 1310,
+    ChangeIdleFlags(ChangeIdleFlags) = 1338,
+    VehicleAddPassiveBoostAction = 1340,
+    VehicleRemovePassiveBoostAction = 1341,
+    NotifyRacingClient(NotifyRacingClient) = 1390,
+    RacingPlayerLoaded(RacingPlayerLoaded) = 1392,
+    SetStatusImmunity(SetStatusImmunity) = 1435,
+    SetPetNameModerated(SetPetNameModerated) = 1448,
+    CancelSkillCast = 1451,
+    ModifyLegoScore(ModifyLegoScore) = 1459,
+    RestoreToPostLoadStats = 1468,
+    SetRailMovement(SetRailMovement) = 1471,
+    StartRailMovement(StartRailMovement) = 1472,
+    NotifyRailActivatorStateChange(NotifyRailActivatorStateChange) = 1478,
+    NotifyRewardMailed(NotifyRewardMailed) = 1480,
+    UpdatePlayerStatistic(UpdatePlayerStatistic) = 1481,
+    RequeryPropertyModels = 1491,
+    NotifyNotEnoughInvSpace(NotifyNotEnoughInvSpace) = 1516,
+    NotifyPropertyOfEditMode(NotifyPropertyOfEditMode) = 1546,
+    PropertyEntranceBegin = 1553,
+    TeamSetLeader(TeamSetLeader) = 1557,
+    TeamGetStatusResponse(TeamGetStatusResponse) = 1559,
+    TeamAddPlayer(TeamAddPlayer) = 1562,
+    TeamRemovePlayer(TeamRemovePlayer) = 1563,
+    SetResurrectRestoreValues(SetResurrectRestoreValues) = 1591,
+    SetPropertyModerationStatus(SetPropertyModerationStatus) = 1594,
+    UpdatePropertyModelCount(UpdatePropertyModelCount) = 1595,
+    VehicleStopBoost(VehicleStopBoost) = 1617,
+    StartCelebrationEffect(StartCelebrationEffect) = 1618,
+    SetLocalTeam(SetLocalTeam) = 1636,
+    ServerDoneLoadingAllObjects = 1642,
+    ResponseMoveItemBetweenInventoryTypes(ResponseMoveItemBetweenInventoryTypes) = 1667,
+    PlayerSetCameraCyclingMode(PlayerSetCameraCyclingMode) = 1676,
+    SetMountInventoryId(SetMountInventoryId) = 1726,
+    NotifyLevelRewards(NotifyLevelRewards) = 1735,
+    ClientCancelMoveSkill = 1747,
+    MarkInventoryItemAsActive(MarkInventoryItemAsActive) = 1767,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct Teleport {
-	#[default(true)]
-	pub ignore_y: bool,
-	#[default(false)]
-	pub set_rotation: bool,
-	#[default(false)]
-	pub skip_all_checks: bool,
-	pub pos: Vector3,
-	#[default(false)]
-	pub use_navmesh: bool,
-	#[default(1.0)]
-	pub w: f32,
-	pub x: f32,
-	pub y: f32,
-	pub z: f32,
+    #[default(true)]
+    pub ignore_y: bool,
+    #[default(false)]
+    pub set_rotation: bool,
+    #[default(false)]
+    pub skip_all_checks: bool,
+    pub pos: Vector3,
+    #[default(false)]
+    pub use_navmesh: bool,
+    #[default(1.0)]
+    pub w: f32,
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct DropClientLoot {
-	#[default(false)]
-	pub use_position: bool,
-	#[default(Vector3::ZERO)]
-	pub final_position: Vector3,
-	pub currency: i32, // todo: unsigned?
-	pub item_template: Lot,
-	pub loot_id: ObjId,
-	pub owner: ObjId,
-	pub source_obj: ObjId,
-	#[default(Vector3::ZERO)]
-	pub spawn_position: Vector3,
+    #[default(false)]
+    pub use_position: bool,
+    #[default(Vector3::ZERO)]
+    pub final_position: Vector3,
+    pub currency: i32, // todo: unsigned?
+    pub item_template: Lot,
+    pub loot_id: ObjId,
+    pub owner: ObjId,
+    pub source_obj: ObjId,
+    #[default(Vector3::ZERO)]
+    pub spawn_position: Vector3,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct Die {
-	#[default(false)]
-	pub client_death: bool,
-	#[default(true)]
-	pub spawn_loot: bool,
-	pub death_type: GmWString,
-	pub direction_relative_angle_xz: f32,
-	pub direction_relative_angle_y: f32,
-	pub direction_relative_force: f32,
-	#[default(KillType::Violent)]
-	pub kill_type: KillType,
-	pub killer_id: ObjId,
-	#[default(OBJID_EMPTY)]
-	pub loot_owner_id: ObjId,
+    #[default(false)]
+    pub client_death: bool,
+    #[default(true)]
+    pub spawn_loot: bool,
+    pub death_type: GmWString,
+    pub direction_relative_angle_xz: f32,
+    pub direction_relative_angle_y: f32,
+    pub direction_relative_force: f32,
+    #[default(KillType::Violent)]
+    pub kill_type: KillType,
+    pub killer_id: ObjId,
+    #[default(OBJID_EMPTY)]
+    pub loot_owner_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct PreloadAnimation {
-	pub animation_id: GmWString,
-	#[default(false)]
-	pub handled: bool,
-	pub respond_obj_id: ObjId,
-	pub user_data: LuNameValue,
+    pub animation_id: GmWString,
+    #[default(false)]
+    pub handled: bool,
+    pub respond_obj_id: ObjId,
+    pub user_data: LuNameValue,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct PlayAnimation {
-	pub animation_id: GmWString,
-	#[default(true)]
-	pub expect_anim_to_exist: bool,
-	pub play_immediate: bool,
-	#[default(false)]
-	pub trigger_on_complete_msg: bool,
-	#[default(SECONDARY_PRIORITY)]
-	pub priority: f32,
-	#[default(1.0)]
-	pub scale: f32,
+    pub animation_id: GmWString,
+    #[default(true)]
+    pub expect_anim_to_exist: bool,
+    pub play_immediate: bool,
+    #[default(false)]
+    pub trigger_on_complete_msg: bool,
+    #[default(SECONDARY_PRIORITY)]
+    pub priority: f32,
+    #[default(1.0)]
+    pub scale: f32,
 }
 
 const SECONDARY_PRIORITY: f32 = 0.4;
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetName {
-	pub name: GmWString,
+    pub name: GmWString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct AddSkill {
-	#[default(0)]
-	pub ai_combat_weight: i32,
-	#[default(false)]
-	pub from_skill_set: bool,
-	#[default(0)]
-	pub cast_type: i32, // todo: type
-	#[default(-1.0)]
-	pub time_secs: f32,
-	#[default(-1)]
-	pub times_can_cast: i32,
-	pub skill_id: u32, // todo: type
-	#[default(-1)]
-	pub slot_id: i32, // todo: type
-	#[default(true)]
-	pub temporary: bool,
+    #[default(0)]
+    pub ai_combat_weight: i32,
+    #[default(false)]
+    pub from_skill_set: bool,
+    #[default(0)]
+    pub cast_type: i32, // todo: type
+    #[default(-1.0)]
+    pub time_secs: f32,
+    #[default(-1)]
+    pub times_can_cast: i32,
+    pub skill_id: u32, // todo: type
+    #[default(-1)]
+    pub slot_id: i32, // todo: type
+    #[default(true)]
+    pub temporary: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetCurrency {
-	pub currency: i64,
-	#[default(LootType::None)]
-	pub loot_type: LootType,
-	pub position: Vector3,
-	#[default(LOT_NULL)]
-	pub source_lot: Lot,
-	#[default(OBJID_EMPTY)]
-	pub source_object: ObjId,
-	#[default(OBJID_EMPTY)]
-	pub source_trade_id: ObjId,
-	#[default(LootType::None)]
-	pub source_type: LootType,
+    pub currency: i64,
+    #[default(LootType::None)]
+    pub loot_type: LootType,
+    pub position: Vector3,
+    #[default(LOT_NULL)]
+    pub source_lot: Lot,
+    #[default(OBJID_EMPTY)]
+    pub source_object: ObjId,
+    #[default(OBJID_EMPTY)]
+    pub source_trade_id: ObjId,
+    #[default(LootType::None)]
+    pub source_type: LootType,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum LootType {
-	None,
-	Chest,
-	Mission,
-	Mail,
-	Currency,
-	Achievement,
-	Trade,
-	Quickbuild,
-	Deletion,
-	Vendor,
-	Activity,
-	Pickup,
-	Brick,
-	Property,
-	Moderation,
-	Exhibit,
-	Inventory,
-	Claimcode,
-	Consumption,
-	Crafting,
-	LevelReward,
-	Relocate,
+    None,
+    Chest,
+    Mission,
+    Mail,
+    Currency,
+    Achievement,
+    Trade,
+    Quickbuild,
+    Deletion,
+    Vendor,
+    Activity,
+    Pickup,
+    Brick,
+    Property,
+    Moderation,
+    Exhibit,
+    Inventory,
+    Claimcode,
+    Consumption,
+    Crafting,
+    LevelReward,
+    Relocate,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct TeamPickupItem {
-	pub loot_id: ObjId,
-	pub loot_owner_id: ObjId,
+    pub loot_id: ObjId,
+    pub loot_owner_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct PlayFxEffect {
-	#[default(-1)]
-	pub effect_id: i32,
-	pub effect_type: GmWString,
-	#[default(1.0)]
-	pub scale: f32,
-	pub name: GmString,
-	#[default(1.0)]
-	pub priority: f32,
-	#[default(OBJID_EMPTY)]
-	pub secondary: ObjId,
-	#[default(true)]
-	pub serialize: bool,
+    #[default(-1)]
+    pub effect_id: i32,
+    pub effect_type: GmWString,
+    #[default(1.0)]
+    pub scale: f32,
+    pub name: GmString,
+    #[default(1.0)]
+    pub priority: f32,
+    #[default(OBJID_EMPTY)]
+    pub secondary: ObjId,
+    #[default(true)]
+    pub serialize: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct StopFxEffect {
-	pub kill_immediate: bool,
-	pub name: GmString,
+    pub kill_immediate: bool,
+    pub name: GmString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct Resurrect {
-	#[default(false)]
-	pub rez_immediately: bool,
+    #[default(false)]
+    pub rez_immediately: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetStunned {
-	#[default(OBJID_EMPTY)]
-	pub originator: ObjId,
-	pub state_change_type: StunState,
-	pub cant_attack: bool,
-	#[default(false)]
-	pub cant_attack_out_change_was_applied: bool,
-	pub cant_equip: bool,
-	#[default(false)]
-	pub cant_equip_out_change_was_applied: bool,
-	pub cant_interact: bool,
-	#[default(false)]
-	pub cant_interact_out_change_was_applied: bool,
-	pub cant_jump: bool,
-	#[default(false)]
-	pub cant_jump_out_change_was_applied: bool,
-	pub cant_move: bool,
-	#[default(false)]
-	pub cant_move_out_change_was_applied: bool,
-	pub cant_turn: bool,
-	#[default(false)]
-	pub cant_turn_out_change_was_applied: bool,
-	#[default(false)]
-	pub cant_use_item: bool,
-	#[default(false)]
-	pub cant_use_item_out_change_was_applied: bool,
-	#[default(false)]
-	pub dont_terminate_interact: bool,
-	#[default(true)]
-	pub ignore_immunity: bool,
+    #[default(OBJID_EMPTY)]
+    pub originator: ObjId,
+    pub state_change_type: StunState,
+    pub cant_attack: bool,
+    #[default(false)]
+    pub cant_attack_out_change_was_applied: bool,
+    pub cant_equip: bool,
+    #[default(false)]
+    pub cant_equip_out_change_was_applied: bool,
+    pub cant_interact: bool,
+    #[default(false)]
+    pub cant_interact_out_change_was_applied: bool,
+    pub cant_jump: bool,
+    #[default(false)]
+    pub cant_jump_out_change_was_applied: bool,
+    pub cant_move: bool,
+    #[default(false)]
+    pub cant_move_out_change_was_applied: bool,
+    pub cant_turn: bool,
+    #[default(false)]
+    pub cant_turn_out_change_was_applied: bool,
+    #[default(false)]
+    pub cant_use_item: bool,
+    #[default(false)]
+    pub cant_use_item_out_change_was_applied: bool,
+    #[default(false)]
+    pub dont_terminate_interact: bool,
+    #[default(true)]
+    pub ignore_immunity: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum StunState {
-	Push,
-	Pop,
+    Push,
+    Pop,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetStunImmunity {
-	#[default(OBJID_EMPTY)]
-	pub caster: ObjId,
-	pub state_change_type: ImmunityState,
-	pub immune_to_stun_attack: bool,
-	pub immune_to_stun_equip: bool,
-	pub immune_to_stun_interact: bool,
-	pub immune_to_stun_jump: bool,
-	pub immune_to_stun_move: bool,
-	pub immune_to_stun_turn: bool,
-	pub immune_to_stun_use_item: bool,
+    #[default(OBJID_EMPTY)]
+    pub caster: ObjId,
+    pub state_change_type: ImmunityState,
+    pub immune_to_stun_attack: bool,
+    pub immune_to_stun_equip: bool,
+    pub immune_to_stun_interact: bool,
+    pub immune_to_stun_jump: bool,
+    pub immune_to_stun_move: bool,
+    pub immune_to_stun_turn: bool,
+    pub immune_to_stun_use_item: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum ImmunityState {
-	Push,
-	Pop,
+    Push,
+    Pop,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct Knockback {
-	#[default(OBJID_EMPTY)]
-	pub caster: ObjId,
-	#[default(OBJID_EMPTY)]
-	pub originator: ObjId,
-	#[default(0)]
-	pub knock_back_time_ms: i32, // todo: unsigned?
-	pub vector: Vector3,
+    #[default(OBJID_EMPTY)]
+    pub caster: ObjId,
+    #[default(OBJID_EMPTY)]
+    pub originator: ObjId,
+    #[default(0)]
+    pub knock_back_time_ms: i32, // todo: unsigned?
+    pub vector: Vector3,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct EnableRebuild {
-	pub enable: bool,
-	pub fail: bool,
-	pub success: bool,
-	#[default(FailReason::NotGiven)]
-	pub fail_reason: FailReason,
-	pub duration: f32,
-	pub user: ObjId,
+    pub enable: bool,
+    pub fail: bool,
+    pub success: bool,
+    #[default(FailReason::NotGiven)]
+    pub fail_reason: FailReason,
+    pub duration: f32,
+    pub user: ObjId,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum FailReason {
-	NotGiven,
-	OutOfImagination,
-	CanceledEarly,
-	BuildEnded,
+    NotGiven,
+    OutOfImagination,
+    CanceledEarly,
+    BuildEnded,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct AddItemToInventoryClientSync {
-	pub bound: bool,
-	pub is_boe: bool,
-	pub is_bop: bool,
-	#[default(LootType::None)]
-	pub loot_type_source: LootType,
-	pub extra_info: LuNameValue,
-	pub obj_template: Lot,
-	#[default(OBJID_EMPTY)]
-	pub subkey: ObjId,
-	#[default(InventoryType::Default)]
-	pub inv_type: InventoryType,
-	#[default(1)]
-	pub item_count: u32,
-	#[default(0)]
-	pub items_total: u32,
-	pub new_obj_id: ObjId,
-	pub flying_loot_posit: Vector3,
-	#[default(true)]
-	pub show_flying_loot: bool,
-	pub slot_id: i32, // todo: unsigned?
+    pub bound: bool,
+    pub is_boe: bool,
+    pub is_bop: bool,
+    #[default(LootType::None)]
+    pub loot_type_source: LootType,
+    pub extra_info: LuNameValue,
+    pub obj_template: Lot,
+    #[default(OBJID_EMPTY)]
+    pub subkey: ObjId,
+    #[default(InventoryType::Default)]
+    pub inv_type: InventoryType,
+    #[default(1)]
+    pub item_count: u32,
+    #[default(0)]
+    pub items_total: u32,
+    pub new_obj_id: ObjId,
+    pub flying_loot_posit: Vector3,
+    #[default(true)]
+    pub show_flying_loot: bool,
+    pub slot_id: i32, // todo: unsigned?
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct OfferMission {
-	pub mission_id: i32,
-	pub offerer: ObjId,
+    pub mission_id: i32,
+    pub offerer: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct NotifyMission {
-	pub mission_id: i32,
-	pub mission_state: MissionState,
-	#[default(false)]
-	pub sending_rewards: bool,
+    pub mission_id: i32,
+    pub mission_state: MissionState,
+    #[default(false)]
+    pub sending_rewards: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct RebuildNotifyState {
-	pub prev_state: RebuildChallengeState,
-	pub state: RebuildChallengeState,
-	pub player: ObjId,
+    pub prev_state: RebuildChallengeState,
+    pub state: RebuildChallengeState,
+    pub player: ObjId,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum RebuildChallengeState {
-	Open = 0,
-	Completed = 2,
-	Resetting = 4,
-	Building = 5,
-	Incomplete = 6,
+    Open = 0,
+    Completed = 2,
+    Resetting = 4,
+    Building = 5,
+    Incomplete = 6,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ToggleInteractionUpdates {
-	#[default(false)]
-	pub enable: bool,
+    #[default(false)]
+    pub enable: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct TerminateInteraction {
-	pub terminator_id: ObjId,
-	pub terminate_type: TerminateType,
+    pub terminator_id: ObjId,
+    pub terminate_type: TerminateType,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum TerminateType {
-	Range,
-	User,
-	FromInteraction,
+    Range,
+    User,
+    FromInteraction,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct EmotePlayed {
-	pub emote_id: i32,
-	pub target_id: ObjId,
+    pub emote_id: i32,
+    pub target_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct TeamSetOffWorldFlag {
-	pub player_id: ObjId,
-	pub zone_id: ZoneId,
+    pub player_id: ObjId,
+    pub zone_id: ZoneId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetInventorySize {
-	pub inventory_type: InventoryType,
-	pub size: i32, // todo: check if can be made unsigned
+    pub inventory_type: InventoryType,
+    pub size: i32, // todo: check if can be made unsigned
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ActivityStop {
-	pub exit: bool,
-	pub user_cancel: bool,
+    pub exit: bool,
+    pub user_cancel: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct CancelMission {
-	pub mission_id: i32,
-	pub reset_completed: bool,
+    pub mission_id: i32,
+    pub reset_completed: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ResetMissions {
-	#[default(-1)]
-	pub mission_id: i32,
+    #[default(-1)]
+    pub mission_id: i32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct NotifyClientShootingGalleryScore {
-	pub add_time: f32,
-	pub score: i32, // todo: unsigned?
-	pub target: ObjId,
-	pub target_pos: Vector3,
+    pub add_time: f32,
+    pub score: i32, // todo: unsigned?
+    pub target: ObjId,
+    pub target_pos: Vector3,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetUserCtrlCompPause {
-	pub paused: bool,
+    pub paused: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct NotifyClientFlagChange {
-	pub flag: bool,
-	pub flag_id: i32,
+    pub flag: bool,
+    pub flag_id: i32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct Help {
-	pub help_id: i32, // todo: type
+    pub help_id: i32, // todo: type
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct VendorTransactionResult {
-	pub result: i32, // todo: type
+    pub result: i32, // todo: type
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct HasBeenCollectedByClient {
-	pub player_id: ObjId,
+    pub player_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct TransferToZone {
-	#[default(false)]
-	pub check_transfer_allowed: bool,
-	#[default(CLONE_ID_INVALID)]
-	pub clone_id: CloneId,
-	#[default(f32::MAX)]
-	pub pos_x: f32,
-	#[default(f32::MAX)]
-	pub pos_y: f32,
-	#[default(f32::MAX)]
-	pub pos_z: f32,
-	#[default(1.0)]
-	pub rot_w: f32,
-	#[default(0.0)]
-	pub rot_x: f32,
-	#[default(0.0)]
-	pub rot_y: f32,
-	#[default(0.0)]
-	pub rot_z: f32,
-	pub spawn_point: GmWString,
-	pub instance_type: u8, // todo: type
-	#[default(MAP_ID_INVALID)]
-	pub zone_id: MapId,
+    #[default(false)]
+    pub check_transfer_allowed: bool,
+    #[default(CLONE_ID_INVALID)]
+    pub clone_id: CloneId,
+    #[default(f32::MAX)]
+    pub pos_x: f32,
+    #[default(f32::MAX)]
+    pub pos_y: f32,
+    #[default(f32::MAX)]
+    pub pos_z: f32,
+    #[default(1.0)]
+    pub rot_w: f32,
+    #[default(0.0)]
+    pub rot_x: f32,
+    #[default(0.0)]
+    pub rot_y: f32,
+    #[default(0.0)]
+    pub rot_z: f32,
+    pub spawn_point: GmWString,
+    pub instance_type: u8, // todo: type
+    #[default(MAP_ID_INVALID)]
+    pub zone_id: MapId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct TransferToZoneCheckedIm {
-	#[default(false)]
-	pub is_there_a_queue: bool,
-	#[default(CLONE_ID_INVALID)]
-	pub clone_id: CloneId,
-	#[default(f32::MAX)]
-	pub pos_x: f32,
-	#[default(f32::MAX)]
-	pub pos_y: f32,
-	#[default(f32::MAX)]
-	pub pos_z: f32,
-	#[default(1.0)]
-	pub rot_w: f32,
-	#[default(0.0)]
-	pub rot_x: f32,
-	#[default(0.0)]
-	pub rot_y: f32,
-	#[default(0.0)]
-	pub rot_z: f32,
-	pub spawn_point: GmWString,
-	pub uc_instance_type: u8,
-	#[default(MAP_ID_INVALID)]
-	pub zone_id: MapId,
+    #[default(false)]
+    pub is_there_a_queue: bool,
+    #[default(CLONE_ID_INVALID)]
+    pub clone_id: CloneId,
+    #[default(f32::MAX)]
+    pub pos_x: f32,
+    #[default(f32::MAX)]
+    pub pos_y: f32,
+    #[default(f32::MAX)]
+    pub pos_z: f32,
+    #[default(1.0)]
+    pub rot_w: f32,
+    #[default(0.0)]
+    pub rot_x: f32,
+    #[default(0.0)]
+    pub rot_y: f32,
+    #[default(0.0)]
+    pub rot_z: f32,
+    pub spawn_point: GmWString,
+    pub uc_instance_type: u8,
+    #[default(MAP_ID_INVALID)]
+    pub zone_id: MapId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct InvalidZoneTransferList {
-	pub customer_feedback_url: GmWString,
-	pub invalid_map_transfer_list: GmWString,
-	pub customer_feedback_on_exit: bool,
-	pub customer_feedback_on_invalid_map_transfer: bool,
+    pub customer_feedback_url: GmWString,
+    pub invalid_map_transfer_list: GmWString,
+    pub customer_feedback_on_exit: bool,
+    pub customer_feedback_on_invalid_map_transfer: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct TransferToLastNonInstance {
-	#[default(true)]
-	pub use_last_position: bool,
-	pub player_id: ObjId,
-	#[default(f32::MAX)]
-	pub pos_x: f32,
-	#[default(f32::MAX)]
-	pub pos_y: f32,
-	#[default(f32::MAX)]
-	pub pos_z: f32,
-	#[default(1.0)]
-	pub rot_w: f32,
-	#[default(0.0)]
-	pub rot_x: f32,
-	#[default(0.0)]
-	pub rot_y: f32,
-	#[default(0.0)]
-	pub rot_z: f32,
+    #[default(true)]
+    pub use_last_position: bool,
+    pub player_id: ObjId,
+    #[default(f32::MAX)]
+    pub pos_x: f32,
+    #[default(f32::MAX)]
+    pub pos_y: f32,
+    #[default(f32::MAX)]
+    pub pos_z: f32,
+    #[default(1.0)]
+    pub rot_w: f32,
+    #[default(0.0)]
+    pub rot_x: f32,
+    #[default(0.0)]
+    pub rot_y: f32,
+    #[default(0.0)]
+    pub rot_z: f32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct DisplayMessageBox {
-	pub show: bool,
-	pub callback_client: ObjId,
-	pub identifier: GmWString,
-	pub image_id: i32,
-	pub text: GmWString,
-	pub user_data: GmWString,
+    pub show: bool,
+    pub callback_client: ObjId,
+    pub identifier: GmWString,
+    pub image_id: i32,
+    pub text: GmWString,
+    pub user_data: GmWString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct Smash {
-	#[default(false)]
-	pub ignore_object_visibility: bool,
-	pub force: f32,
-	pub ghost_opacity: f32,
-	pub killer_id: ObjId,
+    #[default(false)]
+    pub ignore_object_visibility: bool,
+    pub force: f32,
+    pub ghost_opacity: f32,
+    pub killer_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct UnSmash {
-	#[default(OBJID_EMPTY)]
-	pub builder_id: ObjId,
-	#[default(3.0)]
-	pub duration: f32,
+    #[default(OBJID_EMPTY)]
+    pub builder_id: ObjId,
+    #[default(3.0)]
+    pub duration: f32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetGravityScale {
-	pub scale: f32,
+    pub scale: f32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct PlaceModelResponse {
-	#[default(Vector3::ZERO)]
-	pub position: Vector3,
-	#[default(OBJID_EMPTY)]
-	pub property_plaque_id: ObjId,
-	#[default(0)]
-	pub response: i32, // todo: type
-	#[default(Quaternion::IDENTITY)]
-	pub rotation: Quaternion,
+    #[default(Vector3::ZERO)]
+    pub position: Vector3,
+    #[default(OBJID_EMPTY)]
+    pub property_plaque_id: ObjId,
+    #[default(0)]
+    pub response: i32, // todo: type
+    #[default(Quaternion::IDENTITY)]
+    pub rotation: Quaternion,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetJetPackMode {
-	#[default(false)]
-	pub bypass_checks: bool,
-	#[default(false)]
-	pub do_hover: bool,
-	pub use_jetpack: bool,
-	#[default(-1)]
-	pub effect_id: i32,
-	#[default(10.0)]
-	pub airspeed: f32,
-	#[default(15.0)]
-	pub max_airspeed: f32,
-	#[default(1.0)]
-	pub vert_vel: f32,
-	#[default(-1)]
-	pub warning_effect_id: i32,
+    #[default(false)]
+    pub bypass_checks: bool,
+    #[default(false)]
+    pub do_hover: bool,
+    pub use_jetpack: bool,
+    #[default(-1)]
+    pub effect_id: i32,
+    #[default(10.0)]
+    pub airspeed: f32,
+    #[default(15.0)]
+    pub max_airspeed: f32,
+    #[default(1.0)]
+    pub vert_vel: f32,
+    #[default(-1)]
+    pub warning_effect_id: i32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct RegisterPetId {
-	pub obj_id: ObjId,
+    pub obj_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct RegisterPetDbId {
-	pub pet_db_id: ObjId,
+    pub pet_db_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ShowActivityCountdown {
-	pub play_additional_sound: bool,
-	pub play_countdown_sound: bool,
-	pub sound_name: GmWString,
-	pub state_to_play_sound_on: i32, // todo: type
+    pub play_additional_sound: bool,
+    pub play_countdown_sound: bool,
+    pub sound_name: GmWString,
+    pub state_to_play_sound_on: i32, // todo: type
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct DisplayTooltip {
-	#[default(false)]
-	pub do_or_die: bool,
-	#[default(false)]
-	pub no_repeat: bool,
-	#[default(false)]
-	pub no_revive: bool,
-	#[default(false)]
-	pub is_property_tooltip: bool,
-	pub show: bool,
-	#[default(false)]
-	pub translate: bool,
-	pub time: i32, // todo: unsigned?
-	pub id: GmWString,
-	pub localize_params: LuNameValue,
-	pub image_name: GmWString,
-	pub text: GmWString,
+    #[default(false)]
+    pub do_or_die: bool,
+    #[default(false)]
+    pub no_repeat: bool,
+    #[default(false)]
+    pub no_revive: bool,
+    #[default(false)]
+    pub is_property_tooltip: bool,
+    pub show: bool,
+    #[default(false)]
+    pub translate: bool,
+    pub time: i32, // todo: unsigned?
+    pub id: GmWString,
+    pub localize_params: LuNameValue,
+    pub image_name: GmWString,
+    pub text: GmWString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct StartActivityTime {
-	pub start_time: f32,
+    pub start_time: f32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ActivityPause {
-	pub pause: bool,
+    pub pause: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct UseItemResult {
-	pub item_template_id: Lot,
-	#[default(false)]
-	pub use_item_result: bool,
+    pub item_template_id: Lot,
+    #[default(false)]
+    pub use_item_result: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct PetResponse {
-	pub obj_id_pet: ObjId,
-	pub pet_command_type: i32, // todo: type
-	pub response: i32, // todo: type
-	pub type_id: i32, // todo: type
+    pub obj_id_pet: ObjId,
+    pub pet_command_type: i32, // todo: type
+    pub response: i32,         // todo: type
+    pub type_id: i32,          // todo: type
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SendActivitySummaryLeaderboardData {
-	pub game_id: i32, // todo: type
-	pub info_type: i32, // todo: type
-	pub leaderboard_data: LuNameValue,
-	pub throttled: bool,
-	pub weekly: bool,
+    pub game_id: i32,   // todo: type
+    pub info_type: i32, // todo: type
+    pub leaderboard_data: LuNameValue,
+    pub throttled: bool,
+    pub weekly: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ClientNotifyPet {
-	pub obj_id_source: ObjId,
-	pub pet_notification_type: PetNotificationType,
+    pub obj_id_source: ObjId,
+    pub pet_notification_type: PetNotificationType,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct NotifyPetTamingMinigame {
-	pub pet_id: ObjId,
-	pub player_taming_id: ObjId,
-	pub force_teleport: bool,
-	pub notify_type: PetTamingNotifyType,
-	pub pet_dest_pos: Vector3,
-	pub tele_pos: Vector3,
-	#[default(Quaternion::IDENTITY)]
-	pub tele_rot: Quaternion,
+    pub pet_id: ObjId,
+    pub player_taming_id: ObjId,
+    pub force_teleport: bool,
+    pub notify_type: PetTamingNotifyType,
+    pub pet_dest_pos: Vector3,
+    pub tele_pos: Vector3,
+    #[default(Quaternion::IDENTITY)]
+    pub tele_rot: Quaternion,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum PetTamingNotifyType {
-	Success,
-	Quit,
-	Failed,
-	Begin,
-	Ready,
-	NamingPet,
+    Success,
+    Quit,
+    Failed,
+    Begin,
+    Ready,
+    NamingPet,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct PetTamingTryBuildResult {
-	#[default(true)]
-	pub success: bool,
-	#[default(0)]
-	pub num_correct: i32, // todo: check if unsigned
+    #[default(true)]
+    pub success: bool,
+    #[default(0)]
+    pub num_correct: i32, // todo: check if unsigned
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct AddPetToPlayer {
-	pub elemental_type: i32,
-	pub name: GmWString,
-	pub pet_db_id: ObjId,
-	pub pet_lot: Lot,
+    pub elemental_type: i32,
+    pub name: GmWString,
+    pub pet_db_id: ObjId,
+    pub pet_lot: Lot,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetPetName {
-	pub name: GmWString,
-	#[default(OBJID_EMPTY)]
-	pub pet_db_id: ObjId,
+    pub name: GmWString,
+    #[default(OBJID_EMPTY)]
+    pub pet_db_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct PetNameChanged {
-	pub moderation_status: PetModerationStatus,
-	pub name: GmWString,
-	pub owner_name: GmWString,
+    pub moderation_status: PetModerationStatus,
+    pub name: GmWString,
+    pub owner_name: GmWString,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum PetModerationStatus {
-	Unnamed,
-	Unmoderated,
-	Accepted,
-	Rejected,
-	NeedsRename,
-	DoesntMatter,
+    Unnamed,
+    Unmoderated,
+    Accepted,
+    Rejected,
+    NeedsRename,
+    DoesntMatter,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ShowPetActionButton {
-	pub button_label: PetAbilityType,
-	pub show: bool,
+    pub button_label: PetAbilityType,
+    pub show: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum PetAbilityType {
-	Invalid, // todo: option
-	GoToObject,
-	JumpOnObject,
-	DigAtPosition,
+    Invalid, // todo: option
+    GoToObject,
+    JumpOnObject,
+    DigAtPosition,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetEmoteLockState {
-	pub lock: bool,
-	pub emote_id: i32,
+    pub lock: bool,
+    pub emote_id: i32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct UseItemRequirementsResponse {
-	pub use_response: UseItemResponse,
+    pub use_response: UseItemResponse,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum UseItemResponse {
-	NoImaginationForPet = 1,
-	FailedPrecondition,
-	MountsNotAllowed,
+    NoImaginationForPet = 1,
+    FailedPrecondition,
+    MountsNotAllowed,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct PlayEmbeddedEffectOnAllClientsNearObject {
-	pub effect_name: GmWString,
-	pub from_object_id: ObjId,
-	pub radius: f32,
+    pub effect_name: GmWString,
+    pub from_object_id: ObjId,
+    pub radius: f32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct NotifyClientZoneObject {
-	pub name: GmWString,
-	pub param1: i32,
-	pub param2: i32,
-	pub param_obj: ObjId,
-	pub param_str: GmString,
+    pub name: GmWString,
+    pub param1: i32,
+    pub param2: i32,
+    pub param_obj: ObjId,
+    pub param_str: GmString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct UpdateReputation {
-	pub reputation: i64, // todo: check if unsigned
+    pub reputation: i64, // todo: check if unsigned
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct PropertyRentalResponse {
-	pub clone_id: CloneId,
-	pub code: PropertyRentalResponseCode,
-	pub property_id: ObjId,
-	pub rentdue: i64, // todo: type
+    pub clone_id: CloneId,
+    pub code: PropertyRentalResponseCode,
+    pub property_id: ObjId,
+    pub rentdue: i64, // todo: type
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum PropertyRentalResponseCode {
-	Ok = 0,
-	AlreadySold = 4,
-	NoneLeft = 5,
-	YouCantAffordIt,
-	DbFailed,
-	PropertyNotReady,
-	DontHaveAchievement,
+    Ok = 0,
+    AlreadySold = 4,
+    NoneLeft = 5,
+    YouCantAffordIt,
+    DbFailed,
+    PropertyNotReady,
+    DontHaveAchievement,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct PlatformResync {
-	pub reverse: bool,
-	pub stop_at_desired_waypoint: bool,
-	pub command: i32,
-	pub state: i32, // todo: type
-	pub unexpected_command: i32,
-	pub idle_time_elapsed: f32,
-	pub move_time_elapsed: f32,
-	pub percent_between_points: f32,
-	pub desired_waypoint_index: i32,
-	pub index: i32,
-	pub next_index: i32,
-	pub unexpected_location: Vector3,
-	#[default(Quaternion::IDENTITY)]
-	pub unexpected_rotation: Quaternion,
+    pub reverse: bool,
+    pub stop_at_desired_waypoint: bool,
+    pub command: i32,
+    pub state: i32, // todo: type
+    pub unexpected_command: i32,
+    pub idle_time_elapsed: f32,
+    pub move_time_elapsed: f32,
+    pub percent_between_points: f32,
+    pub desired_waypoint_index: i32,
+    pub index: i32,
+    pub next_index: i32,
+    pub unexpected_location: Vector3,
+    #[default(Quaternion::IDENTITY)]
+    pub unexpected_rotation: Quaternion,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct PlayCinematic {
-	#[default(true)]
-	pub allow_ghost_updates: bool,
-	pub close_multi_interact: bool,
-	pub send_server_notify: bool,
-	#[default(false)]
-	pub use_controlled_object_for_audio_listener: bool,
-	#[default(EndBehavior::Return)]
-	pub end_behavior: EndBehavior,
-	#[default(false)]
-	pub hide_player_during_cine: bool,
-	#[default(-1.0)]
-	pub lead_in: f32,
-	#[default(false)]
-	pub leave_player_locked_when_finished: bool,
-	#[default(true)]
-	pub lock_player: bool,
-	pub path_name: GmWString,
-	#[default(false)]
-	pub result: bool,
-	#[default(false)]
-	pub skip_if_same_path: bool,
-	pub start_time_advance: f32,
+    #[default(true)]
+    pub allow_ghost_updates: bool,
+    pub close_multi_interact: bool,
+    pub send_server_notify: bool,
+    #[default(false)]
+    pub use_controlled_object_for_audio_listener: bool,
+    #[default(EndBehavior::Return)]
+    pub end_behavior: EndBehavior,
+    #[default(false)]
+    pub hide_player_during_cine: bool,
+    #[default(-1.0)]
+    pub lead_in: f32,
+    #[default(false)]
+    pub leave_player_locked_when_finished: bool,
+    #[default(true)]
+    pub lock_player: bool,
+    pub path_name: GmWString,
+    #[default(false)]
+    pub result: bool,
+    #[default(false)]
+    pub skip_if_same_path: bool,
+    pub start_time_advance: f32,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum EndBehavior {
-	Return,
-	Wait,
+    Return,
+    Wait,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct EndCinematic {
-	#[default(-1.0)]
-	pub lead_out: f32,
-	#[default(false)]
-	pub leave_player_locked: bool,
-	pub path_name: GmWString,
+    #[default(-1.0)]
+    pub lead_out: f32,
+    #[default(false)]
+    pub leave_player_locked: bool,
+    pub path_name: GmWString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ScriptNetworkVarUpdate {
-	pub table_of_vars: LuNameValue,
+    pub table_of_vars: LuNameValue,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct BroadcastTextToChatbox {
-	pub attrs: LuNameValue,
-	pub text: GmWString,
+    pub attrs: LuNameValue,
+    pub text: GmWString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ServerTradeInvite {
-	#[default(false)]
-	pub need_invite_pop_up: bool,
-	pub requestor: ObjId,
-	pub name: GmWString,
+    #[default(false)]
+    pub need_invite_pop_up: bool,
+    pub requestor: ObjId,
+    pub name: GmWString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ServerTradeInitialReply {
-	pub invitee: ObjId,
-	pub result_type: ResultType,
-	pub name: GmWString,
+    pub invitee: ObjId,
+    pub result_type: ResultType,
+    pub name: GmWString,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum ResultType {
-	NotFound,
-	InviteSent,
-	OutOfRange,
-	AlreadyTrading,
-	GeneralError,
+    NotFound,
+    InviteSent,
+    OutOfRange,
+    AlreadyTrading,
+    GeneralError,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ServerTradeFinalReply {
-	pub result: bool,
-	pub invitee: ObjId,
-	pub name: GmWString,
+    pub result: bool,
+    pub invitee: ObjId,
+    pub name: GmWString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ServerTradeAccept {
-	#[default(false)]
-	pub first: bool,
+    #[default(false)]
+    pub first: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct GetLastCustomBuild {
-	pub tokenized_lot_list: GmWString,
+    pub tokenized_lot_list: GmWString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct OrientToObject {
-	pub obj_id: ObjId,
+    pub obj_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct OrientToPosition {
-	pub position: Vector3,
+    pub position: Vector3,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct OrientToAngle {
-	pub relative_to_current: bool,
-	pub angle: f32,
+    pub relative_to_current: bool,
+    pub angle: f32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct PropertyModerationStatusUpdate {
-	#[default(-1)]
-	pub new_moderation_status: i32, // todo: type
-	pub rejection_reason: GmWString,
+    #[default(-1)]
+    pub new_moderation_status: i32, // todo: type
+    pub rejection_reason: GmWString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct RequestClientBounce {
-	pub bounce_target_id: ObjId,
-	pub bounce_target_pos_on_server: Vector3,
-	pub bounced_obj_lin_vel: Vector3,
-	pub request_source_id: ObjId,
-	pub all_bounced: bool,
-	pub allow_client_override: bool,
+    pub bounce_target_id: ObjId,
+    pub bounce_target_pos_on_server: Vector3,
+    pub bounced_obj_lin_vel: Vector3,
+    pub request_source_id: ObjId,
+    pub all_bounced: bool,
+    pub allow_client_override: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct BouncerActiveStatus {
-	pub active: bool,
+    pub active: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ObjectActivatedClient {
-	pub activator_id: ObjId,
-	pub object_activated_id: ObjId,
+    pub activator_id: ObjId,
+    pub object_activated_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct NotifyClientObject {
-	pub name: GmWString,
-	pub param1: i32,
-	pub param2: i32,
-	pub param_obj: ObjId,
-	pub param_str: GmString,
+    pub name: GmWString,
+    pub param1: i32,
+    pub param2: i32,
+    pub param_obj: ObjId,
+    pub param_str: GmString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct DisplayZoneSummary {
-	#[default(false)]
-	pub is_property_map: bool,
-	#[default(false)]
-	pub is_zone_start: bool,
-	#[default(OBJID_EMPTY)]
-	pub sender: ObjId,
+    #[default(false)]
+    pub is_property_map: bool,
+    #[default(false)]
+    pub is_zone_start: bool,
+    #[default(OBJID_EMPTY)]
+    pub sender: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ModifyPlayerZoneStatistic {
-	#[default(false)]
-	pub set: bool,
-	pub stat_name: GmWString,
-	#[default(0)]
-	pub stat_value: i32,
-	#[default(MAP_ID_INVALID)]
-	pub zone_id: MapId,
+    #[default(false)]
+    pub set: bool,
+    pub stat_name: GmWString,
+    #[default(0)]
+    pub stat_value: i32,
+    #[default(MAP_ID_INVALID)]
+    pub zone_id: MapId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct StartArrangingWithItem {
-	#[default(true)]
-	pub first_time: bool,
-	#[default(OBJID_EMPTY)]
-	pub build_area_id: ObjId,
-	pub build_start_pos: Vector3,
-	pub source_bag: InventoryType,
-	pub source_id: ObjId,
-	pub source_lot: Lot,
-	pub source_type: i32, // todo: type
-	pub target_id: ObjId,
-	pub target_lot: Lot,
-	pub target_pos: Vector3,
-	pub target_type: i32, // todo: type
+    #[default(true)]
+    pub first_time: bool,
+    #[default(OBJID_EMPTY)]
+    pub build_area_id: ObjId,
+    pub build_start_pos: Vector3,
+    pub source_bag: InventoryType,
+    pub source_id: ObjId,
+    pub source_lot: Lot,
+    pub source_type: i32, // todo: type
+    pub target_id: ObjId,
+    pub target_lot: Lot,
+    pub target_pos: Vector3,
+    pub target_type: i32, // todo: type
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct FinishArrangingWithItem {
-	#[default(OBJID_EMPTY)]
-	pub build_area_id: ObjId,
-	pub new_source_bag: InventoryType,
-	pub new_source_id: ObjId,
-	pub new_source_lot: Lot,
-	pub new_source_type: i32, // todo: type
-	pub new_target_id: ObjId,
-	pub new_target_lot: Lot,
-	pub new_target_type: i32, // todo: type
-	pub new_target_pos: Vector3,
-	pub old_item_bag: InventoryType,
-	pub old_item_id: ObjId,
-	pub old_item_lot: Lot,
-	pub old_item_type: i32, // todo: type
+    #[default(OBJID_EMPTY)]
+    pub build_area_id: ObjId,
+    pub new_source_bag: InventoryType,
+    pub new_source_id: ObjId,
+    pub new_source_lot: Lot,
+    pub new_source_type: i32, // todo: type
+    pub new_target_id: ObjId,
+    pub new_target_lot: Lot,
+    pub new_target_type: i32, // todo: type
+    pub new_target_pos: Vector3,
+    pub old_item_bag: InventoryType,
+    pub old_item_id: ObjId,
+    pub old_item_lot: Lot,
+    pub old_item_type: i32, // todo: type
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetBuildModeConfirmed {
-	pub start: bool,
-	#[default(true)]
-	pub warn_visitors: bool,
-	#[default(false)]
-	pub mode_paused: bool,
-	#[default(1)]
-	pub mode_value: i32, // todo: type
-	pub player_id: ObjId,
-	#[default(Vector3::ZERO)]
-	pub start_pos: Vector3,
+    pub start: bool,
+    #[default(true)]
+    pub warn_visitors: bool,
+    #[default(false)]
+    pub mode_paused: bool,
+    #[default(1)]
+    pub mode_value: i32, // todo: type
+    pub player_id: ObjId,
+    #[default(Vector3::ZERO)]
+    pub start_pos: Vector3,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct BuildModeNotificationReport {
-	pub start: bool,
-	pub num_sent: i32,
+    pub start: bool,
+    pub num_sent: i32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetModelToBuild {
-	#[default(LOT_NULL)]
-	pub template_id: Lot,
+    #[default(LOT_NULL)]
+    pub template_id: Lot,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SpawnModelBricks {
-	#[default(0.0)]
-	pub amount: f32,
-	#[default(Vector3::ZERO)]
-	pub pos: Vector3,
+    #[default(0.0)]
+    pub amount: f32,
+    #[default(Vector3::ZERO)]
+    pub pos: Vector3,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct NotifyClientFailedPrecondition {
-	pub failed_reason: GmWString,
-	pub precondition_id: i32,
+    pub failed_reason: GmWString,
+    pub precondition_id: i32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ModuleAssemblyDbDataForClient {
-	pub assembly_id: ObjId,
-	pub blob: GmWString,
+    pub assembly_id: ObjId,
+    pub blob: GmWString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct EchoSyncSkill {
-	#[default(false)]
-	pub done: bool,
-	pub bitstream: Vec<u8>,
-	pub behavior_handle: u32,
-	pub skill_handle: u32,
+    #[default(false)]
+    pub done: bool,
+    pub bitstream: Vec<u8>,
+    pub behavior_handle: u32,
+    pub skill_handle: u32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct DoClientProjectileImpact {
-	#[default(OBJID_EMPTY)]
-	pub org_id: ObjId,
-	#[default(OBJID_EMPTY)]
-	pub owner_id: ObjId,
-	#[default(OBJID_EMPTY)]
-	pub target_id: ObjId,
-	pub bitstream: Vec<u8>,
+    #[default(OBJID_EMPTY)]
+    pub org_id: ObjId,
+    #[default(OBJID_EMPTY)]
+    pub owner_id: ObjId,
+    #[default(OBJID_EMPTY)]
+    pub target_id: ObjId,
+    pub bitstream: Vec<u8>,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetPlayerAllowedRespawn {
-	pub dont_prompt_for_respawn: bool,
+    pub dont_prompt_for_respawn: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct UiMessageServerToSingleClient {
-	pub args: Amf3,
-	pub message_name: GmString,
+    pub args: Amf3,
+    pub message_name: GmString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct UncastSkill {
-	pub skill_id: i32, // todo: type
+    pub skill_id: i32, // todo: type
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct FireEventClientSide {
-	pub args: GmWString,
-	pub object: ObjId,
-	#[default(0)]
-	pub param1: i64,
-	#[default(-1)]
-	pub param2: i32,
-	pub sender_id: ObjId,
+    pub args: GmWString,
+    pub object: ObjId,
+    #[default(0)]
+    pub param1: i64,
+    #[default(-1)]
+    pub param2: i32,
+    pub sender_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ChangeObjectWorldState {
-	#[default(ObjectWorldState::InWorld)]
-	pub new_state: ObjectWorldState,
+    #[default(ObjectWorldState::InWorld)]
+    pub new_state: ObjectWorldState,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum ObjectWorldState {
-	InWorld,
-	Attached,
-	Inventory,
+    InWorld,
+    Attached,
+    Inventory,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct VehicleLockInput {
-	#[default(true)]
-	pub lock_wheels: bool,
-	#[default(false)]
-	pub locked_powerslide: bool,
-	#[default(0.0)]
-	pub locked_x: f32,
-	#[default(0.0)]
-	pub locked_y: f32,
+    #[default(true)]
+    pub lock_wheels: bool,
+    #[default(false)]
+    pub locked_powerslide: bool,
+    #[default(0.0)]
+    pub locked_x: f32,
+    #[default(0.0)]
+    pub locked_y: f32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct VehicleUnlockInput {
-	#[default(true)]
-	pub lock_wheels: bool,
+    #[default(true)]
+    pub lock_wheels: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct RacingResetPlayerToLastReset {
-	pub player_id: ObjId,
+    pub player_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct RacingSetPlayerResetInfo {
-	pub current_lap: i32, // todo: unsigned, type?
-	pub furthest_reset_plane: u32,
-	pub player_id: ObjId,
-	pub respawn_pos: Vector3,
-	pub upcoming_plane: u32,
+    pub current_lap: i32, // todo: unsigned, type?
+    pub furthest_reset_plane: u32,
+    pub player_id: ObjId,
+    pub respawn_pos: Vector3,
+    pub upcoming_plane: u32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct LockNodeRotation {
-	pub node_name: GmString,
+    pub node_name: GmString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct NotifyVehicleOfRacingObject {
-	#[default(OBJID_EMPTY)]
-	pub racing_object_id: ObjId,
+    #[default(OBJID_EMPTY)]
+    pub racing_object_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct PlayerReachedRespawnCheckpoint {
-	pub pos: Vector3,
-	#[default(Quaternion::IDENTITY)]
-	pub rot: Quaternion,
+    pub pos: Vector3,
+    #[default(Quaternion::IDENTITY)]
+    pub rot: Quaternion,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct HandleUgcEquipPostDeleteBasedOnEditMode {
-	pub inv_item: ObjId,
-	#[default(0)]
-	pub items_total: i32,
+    pub inv_item: ObjId,
+    #[default(0)]
+    pub items_total: i32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct HandleUgcEquipPreCreateBasedOnEditMode {
-	pub model_count: i32,
-	pub model_id: ObjId,
+    pub model_count: i32,
+    pub model_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct MatchResponse {
-	pub response: MatchResponseType,
+    pub response: MatchResponseType,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum MatchResponseType {
-	Ok,
-	AlreadyJoined,
-	NotJoined,
-	AlreadyReady,
-	AlreadyNotReady,
-	Fail,
-	TeamFail,
+    Ok,
+    AlreadyJoined,
+    NotJoined,
+    AlreadyReady,
+    AlreadyNotReady,
+    Fail,
+    TeamFail,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct MatchUpdate {
-	pub data: LuNameValue,
-	pub match_update_type: MatchUpdateType,
+    pub data: LuNameValue,
+    pub match_update_type: MatchUpdateType,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum MatchUpdateType {
-	PlayerAdded,
-	PlayerRemoved,
-	PhaseCreated,
-	PhaseWaitReady,
-	PhaseWaitStart,
-	PlayerReady,
-	PlayerNotReady,
-	PlayerUpdate,
+    PlayerAdded,
+    PlayerRemoved,
+    PhaseCreated,
+    PhaseWaitReady,
+    PhaseWaitStart,
+    PlayerReady,
+    PlayerNotReady,
+    PlayerUpdate,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ChangeIdleFlags {
-	#[default(0)]
-	pub off: i32, // todo: type
-	#[default(0)]
-	pub on: i32, // todo: type
+    #[default(0)]
+    pub off: i32, // todo: type
+    #[default(0)]
+    pub on: i32, // todo: type
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct NotifyRacingClient {
-#[default(RacingClientNotificationType::Invalid)]
-	pub event_type: RacingClientNotificationType,
-	pub param1: i32,
-	pub param_obj: ObjId,
-	pub param_str: GmWString,
-	pub single_client: ObjId,
+    #[default(RacingClientNotificationType::Invalid)]
+    pub event_type: RacingClientNotificationType,
+    pub param1: i32,
+    pub param_obj: ObjId,
+    pub param_str: GmWString,
+    pub single_client: ObjId,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum RacingClientNotificationType {
-	Invalid,
-	ActivityStart,
-	RewardPlayer,
-	Exit,
-	Replay,
-	RemovePlayer,
-	LeaderboardUpdated,
+    Invalid,
+    ActivityStart,
+    RewardPlayer,
+    Exit,
+    Replay,
+    RemovePlayer,
+    LeaderboardUpdated,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct RacingPlayerLoaded {
-	pub player_id: ObjId,
-	pub vehicle_id: ObjId,
+    pub player_id: ObjId,
+    pub vehicle_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetStatusImmunity {
-	pub state_change_type: ImmunityState,
-	pub immune_to_basic_attack: bool,
-	pub immune_to_dot: bool,
-	pub immune_to_imagination_gain: bool,
-	pub immune_to_imagination_loss: bool,
-	pub immune_to_interrupt: bool,
-	pub immune_to_knockback: bool,
-	pub immune_to_pull_to_point: bool,
-	pub immune_to_quickbuild_interrupt: bool,
-	pub immune_to_speed: bool,
+    pub state_change_type: ImmunityState,
+    pub immune_to_basic_attack: bool,
+    pub immune_to_dot: bool,
+    pub immune_to_imagination_gain: bool,
+    pub immune_to_imagination_loss: bool,
+    pub immune_to_interrupt: bool,
+    pub immune_to_knockback: bool,
+    pub immune_to_pull_to_point: bool,
+    pub immune_to_quickbuild_interrupt: bool,
+    pub immune_to_speed: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetPetNameModerated {
-	#[default(OBJID_EMPTY)]
-	pub pet_db_id: ObjId,
-	pub moderation_status: PetModerationStatus,
+    #[default(OBJID_EMPTY)]
+    pub pet_db_id: ObjId,
+    pub moderation_status: PetModerationStatus,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ModifyLegoScore {
-	pub score: i64,
-	#[default(LootType::None)]
-	pub source_type: LootType,
+    pub score: i64,
+    #[default(LootType::None)]
+    pub source_type: LootType,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetRailMovement {
-	pub path_go_forward: bool,
-	pub path_name: GmWString,
-	pub path_start: u32,
-	#[default(-1)]
-	pub rail_activator_component_id: i32,
-	#[default(OBJID_EMPTY)]
-	pub rail_activator_obj_id: ObjId,
+    pub path_go_forward: bool,
+    pub path_name: GmWString,
+    pub path_start: u32,
+    #[default(-1)]
+    pub rail_activator_component_id: i32,
+    #[default(OBJID_EMPTY)]
+    pub rail_activator_obj_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct StartRailMovement {
-	#[default(true)]
-	pub damage_immune: bool,
-	#[default(true)]
-	pub no_aggro: bool,
-	#[default(false)]
-	pub notify_activator: bool,
-	#[default(true)]
-	pub show_name_billboard: bool,
-	#[default(true)]
-	pub camera_locked: bool,
-	#[default(true)]
-	pub collision_enabled: bool,
-	pub loop_sound: GmWString,
-	#[default(true)]
-	pub path_go_forward: bool,
-	pub path_name: GmWString,
-	#[default(0)]
-	pub path_start: u32,
-	#[default(-1)]
-	pub rail_activator_component_id: i32,
-	#[default(OBJID_EMPTY)]
-	pub rail_activator_obj_id: ObjId,
-	pub start_sound: GmWString,
-	pub stop_sound: GmWString,
-	#[default(true)]
-	pub use_db: bool,
+    #[default(true)]
+    pub damage_immune: bool,
+    #[default(true)]
+    pub no_aggro: bool,
+    #[default(false)]
+    pub notify_activator: bool,
+    #[default(true)]
+    pub show_name_billboard: bool,
+    #[default(true)]
+    pub camera_locked: bool,
+    #[default(true)]
+    pub collision_enabled: bool,
+    pub loop_sound: GmWString,
+    #[default(true)]
+    pub path_go_forward: bool,
+    pub path_name: GmWString,
+    #[default(0)]
+    pub path_start: u32,
+    #[default(-1)]
+    pub rail_activator_component_id: i32,
+    #[default(OBJID_EMPTY)]
+    pub rail_activator_obj_id: ObjId,
+    pub start_sound: GmWString,
+    pub stop_sound: GmWString,
+    #[default(true)]
+    pub use_db: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct NotifyRailActivatorStateChange {
-	#[default(true)]
-	pub active: bool,
+    #[default(true)]
+    pub active: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct NotifyRewardMailed {
-	pub object_id: ObjId,
-	pub start_point: Vector3,
-	pub subkey: ObjId,
-	pub template_id: Lot,
+    pub object_id: ObjId,
+    pub start_point: Vector3,
+    pub subkey: ObjId,
+    pub template_id: Lot,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct UpdatePlayerStatistic {
-	pub update_id: i32,
-	#[default(1)]
-	pub update_value: i64,
+    pub update_id: i32,
+    #[default(1)]
+    pub update_value: i64,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct NotifyNotEnoughInvSpace {
-	pub free_slots_needed: u32,
-	#[default(InventoryType::Default)]
-	pub inventory_type: InventoryType,
+    pub free_slots_needed: u32,
+    #[default(InventoryType::Default)]
+    pub inventory_type: InventoryType,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct NotifyPropertyOfEditMode {
-	pub editing_active: bool,
+    pub editing_active: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct TeamSetLeader {
-	pub player_id: ObjId,
+    pub player_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct TeamGetStatusResponse {
-	pub leader_id: ObjId,
-	pub leader_zone_id: ZoneId,
-	pub team_buffer: Vec<u8>,
-	pub loot_flag: u8, // todo: type
-	pub num_of_other_players: u8,
-	pub leader_name: GmWString,
+    pub leader_id: ObjId,
+    pub leader_zone_id: ZoneId,
+    pub team_buffer: Vec<u8>,
+    pub loot_flag: u8, // todo: type
+    pub num_of_other_players: u8,
+    pub leader_name: GmWString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct TeamAddPlayer {
-	#[default(false)]
-	pub is_free_trial: bool,
-	#[default(false)]
-	pub local: bool,
-	#[default(false)]
-	pub no_loot_on_death: bool,
-	pub player_id: ObjId,
-	pub player_name: GmWString,
-	#[default(ZoneId::INVALID)]
-	pub zone_id: ZoneId,
+    #[default(false)]
+    pub is_free_trial: bool,
+    #[default(false)]
+    pub local: bool,
+    #[default(false)]
+    pub no_loot_on_death: bool,
+    pub player_id: ObjId,
+    pub player_name: GmWString,
+    #[default(ZoneId::INVALID)]
+    pub zone_id: ZoneId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct TeamRemovePlayer {
-	pub disband: bool,
-	pub is_kicked: bool,
-	pub is_leaving: bool,
-	#[default(false)]
-	pub local: bool,
-	pub leader_id: ObjId,
-	pub player_id: ObjId,
-	pub name: GmWString,
+    pub disband: bool,
+    pub is_kicked: bool,
+    pub is_leaving: bool,
+    #[default(false)]
+    pub local: bool,
+    pub leader_id: ObjId,
+    pub player_id: ObjId,
+    pub name: GmWString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetResurrectRestoreValues {
-	#[default(-1)]
-	pub armor_restore: i32, // todo: option
-	#[default(-1)]
-	pub health_restore: i32, // todo: option
-	#[default(-1)]
-	pub imagination_restore: i32, // todo: option
+    #[default(-1)]
+    pub armor_restore: i32, // todo: option
+    #[default(-1)]
+    pub health_restore: i32, // todo: option
+    #[default(-1)]
+    pub imagination_restore: i32, // todo: option
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetPropertyModerationStatus {
-	#[default(-1)]
-	pub moderation_status: i32, // todo: type
+    #[default(-1)]
+    pub moderation_status: i32, // todo: type
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct UpdatePropertyModelCount {
-	#[default(0)]
-	pub model_count: u32,
+    #[default(0)]
+    pub model_count: u32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct VehicleStopBoost {
-	#[default(true)]
-	pub affect_passive: bool,
+    #[default(true)]
+    pub affect_passive: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct StartCelebrationEffect {
-	pub animation: GmWString,
-	#[default(11164)]
-	pub background_object: Lot,
-	#[default(12458)]
-	pub camera_path_lot: Lot,
-	#[default(1.0)]
-	pub cele_lead_in: f32,
-	#[default(0.8)]
-	pub cele_lead_out: f32,
-	#[default(-1)]
-	pub celebration_id: i32,
-	pub duration: f32,
-	pub icon_id: u32,
-	pub main_text: GmWString,
-	pub mixer_program: GmString,
-	pub music_cue: GmString,
-	pub path_node_name: GmString,
-	pub sound_guid: GmString,
-	pub sub_text: GmWString,
+    pub animation: GmWString,
+    #[default(11164)]
+    pub background_object: Lot,
+    #[default(12458)]
+    pub camera_path_lot: Lot,
+    #[default(1.0)]
+    pub cele_lead_in: f32,
+    #[default(0.8)]
+    pub cele_lead_out: f32,
+    #[default(-1)]
+    pub celebration_id: i32,
+    pub duration: f32,
+    pub icon_id: u32,
+    pub main_text: GmWString,
+    pub mixer_program: GmString,
+    pub music_cue: GmString,
+    pub path_node_name: GmString,
+    pub sound_guid: GmString,
+    pub sub_text: GmWString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetLocalTeam {
-	#[default(false)]
-	pub is_local: bool,
+    #[default(false)]
+    pub is_local: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum ResponseMoveItemResponseCode {
-	Success,
-	FailGeneric,
-	FailInvFull,
-	FailItemNotFound,
-	FailCantMoveToThatInvType,
-	FailNotNearBank,
-	FailCantSwapItems,
-	FailSourceType,
-	FailWrongDestType,
-	FailSwapDestType,
-	FailCantMoveThinkingHat,
-	FailDismountBeforeMoving,
+    Success,
+    FailGeneric,
+    FailInvFull,
+    FailItemNotFound,
+    FailCantMoveToThatInvType,
+    FailNotNearBank,
+    FailCantSwapItems,
+    FailSourceType,
+    FailWrongDestType,
+    FailSwapDestType,
+    FailCantMoveThinkingHat,
+    FailDismountBeforeMoving,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ResponseMoveItemBetweenInventoryTypes {
-	#[default(InventoryType::Default)]
-	pub inv_type_dst: InventoryType,
-	#[default(InventoryType::Default)]
-	pub inv_type_src: InventoryType,
-	#[default(ResponseMoveItemResponseCode::FailGeneric)]
-	pub response_code: ResponseMoveItemResponseCode,
+    #[default(InventoryType::Default)]
+    pub inv_type_dst: InventoryType,
+    #[default(InventoryType::Default)]
+    pub inv_type_src: InventoryType,
+    #[default(ResponseMoveItemResponseCode::FailGeneric)]
+    pub response_code: ResponseMoveItemResponseCode,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct PlayerSetCameraCyclingMode {
-	#[default(true)]
-	pub allow_cycling_while_dead_only: bool,
-	#[default(CyclingMode::AllowCycleTeammates)]
-	pub cycling_mode: CyclingMode,
+    #[default(true)]
+    pub allow_cycling_while_dead_only: bool,
+    #[default(CyclingMode::AllowCycleTeammates)]
+    pub cycling_mode: CyclingMode,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum CyclingMode {
-	AllowCycleTeammates,
-	DisallowCycling,
+    AllowCycleTeammates,
+    DisallowCycling,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetMountInventoryId {
-	#[default(OBJID_EMPTY)]
-	pub inventory_mount_id: ObjId,
+    #[default(OBJID_EMPTY)]
+    pub inventory_mount_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct NotifyLevelRewards {
-	pub level: i32,
-	#[default(false)]
-	pub sending_rewards: bool,
+    pub level: i32,
+    #[default(false)]
+    pub sending_rewards: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct MarkInventoryItemAsActive {
-	#[default(false)]
-	pub active: bool,
-	#[default(UnequippableActiveType::Pet)]
-	pub unequippable_active_type: UnequippableActiveType,
-	#[default(OBJID_EMPTY)]
-	pub item_id: ObjId,
+    #[default(false)]
+    pub active: bool,
+    #[default(UnequippableActiveType::Pet)]
+    pub unequippable_active_type: UnequippableActiveType,
+    #[default(OBJID_EMPTY)]
+    pub item_id: ObjId,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum UnequippableActiveType {
-	Pet,
-	Mount,
+    Pet,
+    Mount,
 }

--- a/src/world/gm/mod.rs
+++ b/src/world/gm/mod.rs
@@ -1,36 +1,36 @@
 pub mod client;
 pub mod server;
 
-use std::io::{Read, Write};
 use std::io::Result as Res;
+use std::io::{Read, Write};
 
 use endio::{Deserialize, LERead, LEWrite, Serialize};
 use lu_packets_derive::{GameMessage, GmParam};
 
-use crate::common::{LuVarString, LuVarWString, ObjId, OBJID_EMPTY};
 use super::{Lot, LOT_NULL};
+use crate::common::{LuVarString, LuVarWString, ObjId, OBJID_EMPTY};
 
 type GmString = LuVarString<u32>;
 type GmWString = LuVarWString<u32>;
 
 pub(super) trait GmParam: Sized {
-	fn deserialize<R: Read>(reader: &mut R) -> Res<Self>;
-	fn serialize<W: Write>(&self, writer: &mut W) -> Res<()>;
+    fn deserialize<R: Read>(reader: &mut R) -> Res<Self>;
+    fn serialize<W: Write>(&self, writer: &mut W) -> Res<()>;
 }
 
 /// Implements `GmParam` by forwarding to [`Deserialize`] and [`Serialize`].
 macro_rules! gm_param {
-	($typ:ty) => {
-		impl crate::world::gm::GmParam for $typ {
-			fn deserialize<R: ::std::io::Read>(reader: &mut R) -> ::std::io::Result<Self> {
-				::endio::LERead::read(reader)
-			}
+    ($typ:ty) => {
+        impl crate::world::gm::GmParam for $typ {
+            fn deserialize<R: ::std::io::Read>(reader: &mut R) -> ::std::io::Result<Self> {
+                ::endio::LERead::read(reader)
+            }
 
-			fn serialize<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
-				::endio::LEWrite::write(writer, self)
-			}
-		}
-	}
+            fn serialize<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
+                ::endio::LEWrite::write(writer, self)
+            }
+        }
+    };
 }
 
 gm_param!(u8);
@@ -44,147 +44,149 @@ gm_param!(GmString);
 gm_param!(GmWString);
 
 impl GmParam for Vec<u8> {
-	fn deserialize<R: Read>(reader: &mut R) -> Res<Self> {
-		let str_len: u32 = LERead::read(reader)?;
-		let str_len = str_len as usize;
-		let mut vec = Vec::with_capacity(str_len);
-		unsafe { vec.set_len(str_len); }
-		Read::read(reader, &mut vec)?;
-		Ok(vec)
-	}
+    fn deserialize<R: Read>(reader: &mut R) -> Res<Self> {
+        let str_len: u32 = LERead::read(reader)?;
+        let str_len = str_len as usize;
+        let mut vec = Vec::with_capacity(str_len);
+        unsafe {
+            vec.set_len(str_len);
+        }
+        Read::read(reader, &mut vec)?;
+        Ok(vec)
+    }
 
-	fn serialize<W: Write>(&self, writer: &mut W) -> Res<()> {
-		LEWrite::write(writer, self.len() as u32)?;
-		Write::write_all(writer, self)
-	}
+    fn serialize<W: Write>(&self, writer: &mut W) -> Res<()> {
+        LEWrite::write(writer, self.len() as u32)?;
+        Write::write_all(writer, self)
+    }
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum InventoryType {
-	Default,
-	Bank,
-	Brick,
-	ModelsInBbb,
-	TempEquip,
-	Model,
-	ModuleInUse,
-	Behavior,
-	Property,
-	BrickInBbb,
-	Vendor,
-	Buyback,
-	Quest,
-	Donation,
-	BankModel,
-	BankBehavior,
+    Default,
+    Bank,
+    Brick,
+    ModelsInBbb,
+    TempEquip,
+    Model,
+    ModuleInUse,
+    Behavior,
+    Property,
+    BrickInBbb,
+    Vendor,
+    Buyback,
+    Quest,
+    Donation,
+    BankModel,
+    BankBehavior,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum KillType {
-	Violent,
-	Silent,
+    Violent,
+    Silent,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum MissionState {
-	Unavailable = 0,
-	Available = 1,
-	Active = 2,
-	ReadyToComplete = 4,
-	Completed = 8,
-	CompleteAndAvailable = 9,
-	CompleteAndActive = 10,
-	CompleteAndReadyToComplete = 12,
-	Fail = 16,
-	ReadyToCompleteReported = 32,
+    Unavailable = 0,
+    Available = 1,
+    Active = 2,
+    ReadyToComplete = 4,
+    Completed = 8,
+    CompleteAndAvailable = 9,
+    CompleteAndActive = 10,
+    CompleteAndReadyToComplete = 12,
+    Fail = 16,
+    ReadyToCompleteReported = 32,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum PetNotificationType {
-	OwnerDied = 1,
-	OwnerOnPetBouncer,
-	OwnerUsedBouncer,
-	PetOnJumpActivatedObj,
-	PetOffSwitch,
-	PetAtDigLocation,
-	PetLeftDigLocation,
-	EndSignal,
-	PetToDespawn,
-	GoToObject,
-	OwnerResurrected,
-	OwnerOnDig,
-	Released,
-	OwnerOffPetBouncer,
-	OwnerOffDig,
+    OwnerDied = 1,
+    OwnerOnPetBouncer,
+    OwnerUsedBouncer,
+    PetOnJumpActivatedObj,
+    PetOffSwitch,
+    PetAtDigLocation,
+    PetLeftDigLocation,
+    EndSignal,
+    PetToDespawn,
+    GoToObject,
+    OwnerResurrected,
+    OwnerOnDig,
+    Released,
+    OwnerOffPetBouncer,
+    OwnerOffDig,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct RemoveSkill {
-	#[default(false)]
-	pub from_skill_set: bool,
-	pub skill_id: u32,
+    #[default(false)]
+    pub from_skill_set: bool,
+    pub skill_id: u32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct EquipInventory {
-	#[default(false)]
-	pub ignore_cooldown: bool,
-	pub out_success: bool,
-	pub item_to_equip: ObjId,
+    #[default(false)]
+    pub ignore_cooldown: bool,
+    pub out_success: bool,
+    pub item_to_equip: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetIgnoreProjectileCollision {
-	#[default(false)]
-	pub should_ignore: bool,
+    #[default(false)]
+    pub should_ignore: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct UnEquipInventory {
-	#[default(false)]
-	pub even_if_dead: bool,
-	#[default(false)]
-	pub ignore_cooldown: bool,
-	pub out_success: bool,
-	pub item_to_unequip: ObjId,
-	#[default(OBJID_EMPTY)]
-	pub replacement_object_id: ObjId,
+    #[default(false)]
+    pub even_if_dead: bool,
+    #[default(false)]
+    pub ignore_cooldown: bool,
+    pub out_success: bool,
+    pub item_to_unequip: ObjId,
+    #[default(OBJID_EMPTY)]
+    pub replacement_object_id: ObjId,
 }
 
 const INVENTORY_INVALID: i32 = -1;
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct MoveItemInInventory {
-	#[default(INVENTORY_INVALID)]
-	pub dest_inv_type: i32, // todo: type
-	pub obj_id: ObjId,
-	pub inventory_type: InventoryType,
-	pub response_code: i32, // todo: type
-	pub slot: i32, // todo: unsigned?
+    #[default(INVENTORY_INVALID)]
+    pub dest_inv_type: i32, // todo: type
+    pub obj_id: ObjId,
+    pub inventory_type: InventoryType,
+    pub response_code: i32, // todo: type
+    pub slot: i32,          // todo: unsigned?
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct MoveInventoryBatch {
-	#[default(false)]
-	pub allow_partial: bool,
-	#[default(false)]
-	pub out_success: bool,
-	#[default(1)]
-	pub count: u32,
-	#[default(InventoryType::Default)]
-	pub dst_bag: InventoryType,
-	#[default(LOT_NULL)]
-	pub move_lot: Lot,
-	#[default(OBJID_EMPTY)]
-	pub move_subkey: ObjId,
-	#[default(false)]
-	pub show_flying_loot: bool,
-	#[default(InventoryType::Default)]
-	pub src_bag: InventoryType,
-	#[default(OBJID_EMPTY)]
-	pub start_object_id: ObjId,
+    #[default(false)]
+    pub allow_partial: bool,
+    #[default(false)]
+    pub out_success: bool,
+    #[default(1)]
+    pub count: u32,
+    #[default(InventoryType::Default)]
+    pub dst_bag: InventoryType,
+    #[default(LOT_NULL)]
+    pub move_lot: Lot,
+    #[default(OBJID_EMPTY)]
+    pub move_subkey: ObjId,
+    #[default(false)]
+    pub show_flying_loot: bool,
+    #[default(InventoryType::Default)]
+    pub src_bag: InventoryType,
+    #[default(OBJID_EMPTY)]
+    pub start_object_id: ObjId,
 }

--- a/src/world/gm/mod.rs
+++ b/src/world/gm/mod.rs
@@ -51,7 +51,7 @@ impl GmParam for Vec<u8> {
         unsafe {
             vec.set_len(str_len);
         }
-        Read::read(reader, &mut vec)?;
+        Read::read_exact(reader, &mut vec)?;
         Ok(vec)
     }
 

--- a/src/world/gm/server/mod.rs
+++ b/src/world/gm/server/mod.rs
@@ -5,920 +5,923 @@ use lu_packets_derive::{GameMessage, GmParam, VariantTests};
 
 use crate::common::{ObjId, OBJID_EMPTY};
 
-use crate::world::{Lot, LOT_NULL, Quaternion, Vector3};
-use crate::world::amf3::Amf3;
-pub use super::{EquipInventory, InventoryType, KillType, UnEquipInventory, MissionState, PetNotificationType, MoveItemInInventory, MoveInventoryBatch, SetIgnoreProjectileCollision};
+pub use super::{
+    EquipInventory, InventoryType, KillType, MissionState, MoveInventoryBatch, MoveItemInInventory,
+    PetNotificationType, SetIgnoreProjectileCollision, UnEquipInventory,
+};
 use super::{GmString, GmWString};
+use crate::world::amf3::Amf3;
+use crate::world::{Lot, Quaternion, Vector3, LOT_NULL};
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct SubjectGameMessage {
-	pub subject_id: ObjId,
-	pub message: GameMessage,
+    pub subject_id: ObjId,
+    pub message: GameMessage,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize, VariantTests)]
 #[repr(u16)]
 pub enum GameMessage {
-	RequestDie(RequestDie) = 38,
-	PlayEmote(PlayEmote) = 41,
-	ControlBehaviors(ControlBehaviors) = 48,
-	StartSkill(StartSkill) = 119,
-	CasterDead(CasterDead) = 120,
-	VerifyAck(VerifyAck) = 121,
-	SelectSkill(SelectSkill) = 124,
-	PickupCurrency(PickupCurrency) = 137,
-	PickupItem(PickupItem) = 139,
-	RequestResurrect = 159,
-	PopEquippedItemsState = 192,
-	RebuildCancel(RebuildCancel) = 209,
-	MoveItemInInventory(MoveItemInInventory) = 224,
-	EquipInventory(EquipInventory) = 231,
-	UnEquipInventory(UnEquipInventory) = 233,
-	RespondToMission(RespondToMission) = 249,
-	ServerTerminateInteraction(ServerTerminateInteraction) = 358,
-	RequestUse(RequestUse) = 364,
-	BuyFromVendor(BuyFromVendor) = 373,
-	SellToVendor(SellToVendor) = 374,
-	CancelDonationOnPlayer = 379,
-	AcknowledgePossession(AcknowledgePossession) = 391,
-	RequestActivityExit(RequestActivityExit) = 404,
-	ShootingGalleryFire(ShootingGalleryFire) = 411,
-	RequestVendorStatusUpdate = 416,
-	ClientItemConsumed(ClientItemConsumed) = 428,
-	UpdateShootingGalleryRotation(UpdateShootingGalleryRotation) = 448,
-	SetTooltipFlag(SetTooltipFlag) = 469,
-	SetFlag(SetFlag) = 471,
-	HasBeenCollected(HasBeenCollected) = 486,
-	DespawnPet(DespawnPet) = 499,
-	PlayerLoaded(PlayerLoaded) = 505,
-	RequestLinkedMission(RequestLinkedMission) = 515,
-	MissionDialogueOk(MissionDialogueOk) = 520,
-	MessageBoxRespond(MessageBoxRespond) = 530,
-	ChoiceBoxRespond(ChoiceBoxRespond) = 531,
-	UseNonEquipmentItem(UseNonEquipmentItem) = 603,
-	FetchModelMetadataRequest(FetchModelMetadataRequest) = 638,
-	CommandPet(CommandPet) = 640,
-	RequestActivitySummaryLeaderboardData(RequestActivitySummaryLeaderboardData) = 648,
-	NotifyPet(NotifyPet) = 660,
-	StartServerPetMinigameTimer = 662,
-	ClientExitTamingMinigame(ClientExitTamingMinigame) = 663,
-	PetTamingMinigameResult(PetTamingMinigameResult) = 667,
-	NotifyTamingBuildSuccess(NotifyTamingBuildSuccess) = 673,
-	RequestSetPetName(RequestSetPetName) = 683,
-	CinematicUpdate(CinematicUpdate) = 764,
-	FireEventServerSide(FireEventServerSide) = 770,
-	QueryPropertyData = 717,
-	PropertyEditorBegin(PropertyEditorBegin) = 724,
-	PropertyEditorEnd = 725,
-	RequestPlatformResync = 760,
-	ToggleGhostReferenceOverride(ToggleGhostReferenceOverride) = 767,
-	SetGhostReferencePosition(SetGhostReferencePosition) = 768,
-	UpdateModelFromClient(UpdateModelFromClient) = 793,
-	DeleteModelFromClient(DeleteModelFromClient) = 794,
-	EnterProperty1(EnterProperty1) = 840,
-	PropertyEntranceSync(PropertyEntranceSync) = 842,
-	ParseChatMessage(ParseChatMessage) = 850,
-	SetMissionTypeState(SetMissionTypeState) = 851,
-	ClientTradeRequest(ClientTradeRequest) = 868,
-	ClientTradeCancel = 878,
-	ClientTradeAccept(ClientTradeAccept) = 880,
-	ReadyForUpdates(ReadyForUpdates) = 888,
-	SetLastCustomBuild(SetLastCustomBuild) = 890,
-	SetIgnoreProjectileCollision(SetIgnoreProjectileCollision) = 903,
-	PropertyModerationAction(PropertyModerationAction) = 915,
-	BounceNotification(BounceNotification) = 932,
-	MoveInventoryBatch(MoveInventoryBatch) = 957,
-	SetBbbAutosave(SetBbbAutosave) = 996,
-	BbbLoadItemRequest(BbbLoadItemRequest) = 1000,
-	BbbSaveRequest(BbbSaveRequest) = 1001,
-	BbbResetMetadataSourceItem = 1004,
-	ZoneSummaryDismissed(ZoneSummaryDismissed) = 1044,
-	ActivityStateChangeRequest(ActivityStateChangeRequest) = 1053,
-	StartBuildingWithItem(StartBuildingWithItem) = 1057,
-	DoneArrangingWithItem(DoneArrangingWithItem) = 1063,
-	SetBuildMode(SetBuildMode) = 1068,
-	BuildModeSet(BuildModeSet) = 1069,
-	BuildExitConfirmation(BuildExitConfirmation) = 1072,
-	MoveItemBetweenInventoryTypes(MoveItemBetweenInventoryTypes) = 1093,
-	MissionDialogueCancelled(MissionDialogueCancelled) = 1129,
-	ModuleAssemblyQueryData = 1132,
-	SyncSkill(SyncSkill) = 1145,
-	RequestServerProjectileImpact(RequestServerProjectileImpact) = 1148,
-	ToggleSendingPositionUpdates(ToggleSendingPositionUpdates) = 1166,
-	PlacePropertyModel(PlacePropertyModel) = 1170,
-	ReportBug(ReportBug) = 1198,
-	RequestSmashPlayer = 1202,
-	ResyncEquipment = 1238,
-	RacingPlayerInfoResetFinished(RacingPlayerInfoResetFinished) = 1255,
-	VehicleSetWheelLockState(VehicleSetWheelLockState) = 1273,
-	PropertyContentsFromClient(PropertyContentsFromClient) = 1305,
-	VehicleNotifyServerAddPassiveBoostAction = 1342,
-	VehicleNotifyServerRemovePassiveBoostAction = 1343,
-	ZonePropertyModelRotated(ZonePropertyModelRotated) = 1370,
-	ZonePropertyModelRemovedWhileEquipped(ZonePropertyModelRemovedWhileEquipped) = 1371,
-	ZonePropertyModelEquipped(ZonePropertyModelEquipped) = 1372,
-	RacingClientReady(RacingClientReady) = 1393,
-	ResetPropertyBehaviors(ResetPropertyBehaviors) = 1406,
-	SetConsumableItem(SetConsumableItem) = 1409,
-	UsedInformationPlaque(UsedInformationPlaque) = 1419,
-	ActivateBrickMode(ActivateBrickMode) = 1438,
-	CancelRailMovement(CancelRailMovement) = 1474,
-	ClientRailMovementReady = 1476,
-	PlayerRailArrivedNotification(PlayerRailArrivedNotification) = 1477,
-	RequestRailActivatorState = 1479,
-	ModifyGhostingDistance(ModifyGhostingDistance) = 1485,
-	ModularAssemblyNifCompleted(ModularAssemblyNifCompleted) = 1498,
-	GetHotPropertyData = 1511,
-	UpdatePropertyPerformanceCost(UpdatePropertyPerformanceCost) = 1547,
-	SetEmotesEnabled(SetEmotesEnabled) = 1577,
-	VehicleNotifyHitImaginationServer(VehicleNotifyHitImaginationServer) = 1606,
-	CelebrationCompleted = 1632,
-	RequestMoveItemBetweenInventoryTypes(RequestMoveItemBetweenInventoryTypes) = 1666,
-	NotifyServerLevelProcessingComplete = 1734,
-	ServerCancelMoveSkill = 1746,
-	DismountComplete(DismountComplete) = 1756,
+    RequestDie(RequestDie) = 38,
+    PlayEmote(PlayEmote) = 41,
+    ControlBehaviors(ControlBehaviors) = 48,
+    StartSkill(StartSkill) = 119,
+    CasterDead(CasterDead) = 120,
+    VerifyAck(VerifyAck) = 121,
+    SelectSkill(SelectSkill) = 124,
+    PickupCurrency(PickupCurrency) = 137,
+    PickupItem(PickupItem) = 139,
+    RequestResurrect = 159,
+    PopEquippedItemsState = 192,
+    RebuildCancel(RebuildCancel) = 209,
+    MoveItemInInventory(MoveItemInInventory) = 224,
+    EquipInventory(EquipInventory) = 231,
+    UnEquipInventory(UnEquipInventory) = 233,
+    RespondToMission(RespondToMission) = 249,
+    ServerTerminateInteraction(ServerTerminateInteraction) = 358,
+    RequestUse(RequestUse) = 364,
+    BuyFromVendor(BuyFromVendor) = 373,
+    SellToVendor(SellToVendor) = 374,
+    CancelDonationOnPlayer = 379,
+    AcknowledgePossession(AcknowledgePossession) = 391,
+    RequestActivityExit(RequestActivityExit) = 404,
+    ShootingGalleryFire(ShootingGalleryFire) = 411,
+    RequestVendorStatusUpdate = 416,
+    ClientItemConsumed(ClientItemConsumed) = 428,
+    UpdateShootingGalleryRotation(UpdateShootingGalleryRotation) = 448,
+    SetTooltipFlag(SetTooltipFlag) = 469,
+    SetFlag(SetFlag) = 471,
+    HasBeenCollected(HasBeenCollected) = 486,
+    DespawnPet(DespawnPet) = 499,
+    PlayerLoaded(PlayerLoaded) = 505,
+    RequestLinkedMission(RequestLinkedMission) = 515,
+    MissionDialogueOk(MissionDialogueOk) = 520,
+    MessageBoxRespond(MessageBoxRespond) = 530,
+    ChoiceBoxRespond(ChoiceBoxRespond) = 531,
+    UseNonEquipmentItem(UseNonEquipmentItem) = 603,
+    FetchModelMetadataRequest(FetchModelMetadataRequest) = 638,
+    CommandPet(CommandPet) = 640,
+    RequestActivitySummaryLeaderboardData(RequestActivitySummaryLeaderboardData) = 648,
+    NotifyPet(NotifyPet) = 660,
+    StartServerPetMinigameTimer = 662,
+    ClientExitTamingMinigame(ClientExitTamingMinigame) = 663,
+    PetTamingMinigameResult(PetTamingMinigameResult) = 667,
+    NotifyTamingBuildSuccess(NotifyTamingBuildSuccess) = 673,
+    RequestSetPetName(RequestSetPetName) = 683,
+    CinematicUpdate(CinematicUpdate) = 764,
+    FireEventServerSide(FireEventServerSide) = 770,
+    QueryPropertyData = 717,
+    PropertyEditorBegin(PropertyEditorBegin) = 724,
+    PropertyEditorEnd = 725,
+    RequestPlatformResync = 760,
+    ToggleGhostReferenceOverride(ToggleGhostReferenceOverride) = 767,
+    SetGhostReferencePosition(SetGhostReferencePosition) = 768,
+    UpdateModelFromClient(UpdateModelFromClient) = 793,
+    DeleteModelFromClient(DeleteModelFromClient) = 794,
+    EnterProperty1(EnterProperty1) = 840,
+    PropertyEntranceSync(PropertyEntranceSync) = 842,
+    ParseChatMessage(ParseChatMessage) = 850,
+    SetMissionTypeState(SetMissionTypeState) = 851,
+    ClientTradeRequest(ClientTradeRequest) = 868,
+    ClientTradeCancel = 878,
+    ClientTradeAccept(ClientTradeAccept) = 880,
+    ReadyForUpdates(ReadyForUpdates) = 888,
+    SetLastCustomBuild(SetLastCustomBuild) = 890,
+    SetIgnoreProjectileCollision(SetIgnoreProjectileCollision) = 903,
+    PropertyModerationAction(PropertyModerationAction) = 915,
+    BounceNotification(BounceNotification) = 932,
+    MoveInventoryBatch(MoveInventoryBatch) = 957,
+    SetBbbAutosave(SetBbbAutosave) = 996,
+    BbbLoadItemRequest(BbbLoadItemRequest) = 1000,
+    BbbSaveRequest(BbbSaveRequest) = 1001,
+    BbbResetMetadataSourceItem = 1004,
+    ZoneSummaryDismissed(ZoneSummaryDismissed) = 1044,
+    ActivityStateChangeRequest(ActivityStateChangeRequest) = 1053,
+    StartBuildingWithItem(StartBuildingWithItem) = 1057,
+    DoneArrangingWithItem(DoneArrangingWithItem) = 1063,
+    SetBuildMode(SetBuildMode) = 1068,
+    BuildModeSet(BuildModeSet) = 1069,
+    BuildExitConfirmation(BuildExitConfirmation) = 1072,
+    MoveItemBetweenInventoryTypes(MoveItemBetweenInventoryTypes) = 1093,
+    MissionDialogueCancelled(MissionDialogueCancelled) = 1129,
+    ModuleAssemblyQueryData = 1132,
+    SyncSkill(SyncSkill) = 1145,
+    RequestServerProjectileImpact(RequestServerProjectileImpact) = 1148,
+    ToggleSendingPositionUpdates(ToggleSendingPositionUpdates) = 1166,
+    PlacePropertyModel(PlacePropertyModel) = 1170,
+    ReportBug(ReportBug) = 1198,
+    RequestSmashPlayer = 1202,
+    ResyncEquipment = 1238,
+    RacingPlayerInfoResetFinished(RacingPlayerInfoResetFinished) = 1255,
+    VehicleSetWheelLockState(VehicleSetWheelLockState) = 1273,
+    PropertyContentsFromClient(PropertyContentsFromClient) = 1305,
+    VehicleNotifyServerAddPassiveBoostAction = 1342,
+    VehicleNotifyServerRemovePassiveBoostAction = 1343,
+    ZonePropertyModelRotated(ZonePropertyModelRotated) = 1370,
+    ZonePropertyModelRemovedWhileEquipped(ZonePropertyModelRemovedWhileEquipped) = 1371,
+    ZonePropertyModelEquipped(ZonePropertyModelEquipped) = 1372,
+    RacingClientReady(RacingClientReady) = 1393,
+    ResetPropertyBehaviors(ResetPropertyBehaviors) = 1406,
+    SetConsumableItem(SetConsumableItem) = 1409,
+    UsedInformationPlaque(UsedInformationPlaque) = 1419,
+    ActivateBrickMode(ActivateBrickMode) = 1438,
+    CancelRailMovement(CancelRailMovement) = 1474,
+    ClientRailMovementReady = 1476,
+    PlayerRailArrivedNotification(PlayerRailArrivedNotification) = 1477,
+    RequestRailActivatorState = 1479,
+    ModifyGhostingDistance(ModifyGhostingDistance) = 1485,
+    ModularAssemblyNifCompleted(ModularAssemblyNifCompleted) = 1498,
+    GetHotPropertyData = 1511,
+    UpdatePropertyPerformanceCost(UpdatePropertyPerformanceCost) = 1547,
+    SetEmotesEnabled(SetEmotesEnabled) = 1577,
+    VehicleNotifyHitImaginationServer(VehicleNotifyHitImaginationServer) = 1606,
+    CelebrationCompleted = 1632,
+    RequestMoveItemBetweenInventoryTypes(RequestMoveItemBetweenInventoryTypes) = 1666,
+    NotifyServerLevelProcessingComplete = 1734,
+    ServerCancelMoveSkill = 1746,
+    DismountComplete(DismountComplete) = 1756,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct RequestDie {
-	pub unknown: bool,
-	pub death_type: GmWString,
-	pub direction_relative_angle_xz: f32,
-	pub direction_relative_angle_y: f32,
-	pub direction_relative_force: f32,
-	#[default(KillType::Violent)]
-	pub kill_type: KillType,
-	pub killer_id: ObjId,
-	pub loot_owner_id: ObjId,
+    pub unknown: bool,
+    pub death_type: GmWString,
+    pub direction_relative_angle_xz: f32,
+    pub direction_relative_angle_y: f32,
+    pub direction_relative_force: f32,
+    #[default(KillType::Violent)]
+    pub kill_type: KillType,
+    pub killer_id: ObjId,
+    pub loot_owner_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct PlayEmote {
-	pub emote_id: i32,
-	pub target_id: ObjId,
+    pub emote_id: i32,
+    pub target_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ControlBehaviors {
-	pub args: Amf3,
-	pub command: GmString,
+    pub args: Amf3,
+    pub command: GmString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct StartSkill {
-	#[default(false)]
-	pub used_mouse: bool,
-	#[default(OBJID_EMPTY)]
-	pub consumable_item_id: ObjId,
-	#[default(0.0)]
-	pub caster_latency: f32,
-	#[default(0)]
-	pub cast_type: i32, // todo: type
-	#[default(Vector3::ZERO)]
-	pub last_clicked_posit: Vector3,
-	pub optional_originator_id: ObjId,
-	#[default(OBJID_EMPTY)]
-	pub optional_target_id: ObjId,
-	#[default(Quaternion::IDENTITY)]
-	pub originator_rot: Quaternion,
-	pub bitstream: Vec<u8>,
-	pub skill_id: u32, // todo: type
-	#[default(0)]
-	pub skill_handle: u32,
+    #[default(false)]
+    pub used_mouse: bool,
+    #[default(OBJID_EMPTY)]
+    pub consumable_item_id: ObjId,
+    #[default(0.0)]
+    pub caster_latency: f32,
+    #[default(0)]
+    pub cast_type: i32, // todo: type
+    #[default(Vector3::ZERO)]
+    pub last_clicked_posit: Vector3,
+    pub optional_originator_id: ObjId,
+    #[default(OBJID_EMPTY)]
+    pub optional_target_id: ObjId,
+    #[default(Quaternion::IDENTITY)]
+    pub originator_rot: Quaternion,
+    pub bitstream: Vec<u8>,
+    pub skill_id: u32, // todo: type
+    #[default(0)]
+    pub skill_handle: u32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct CasterDead {
-	#[default(OBJID_EMPTY)]
-	pub caster: ObjId,
-	#[default(0)]
-	pub skill_handle: u32,
+    #[default(OBJID_EMPTY)]
+    pub caster: ObjId,
+    #[default(0)]
+    pub skill_handle: u32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct VerifyAck {
-	#[default(false)]
-	pub different: bool,
-	pub bitstream: Vec<u8>,
-	#[default(0)]
-	pub handle: u32,
+    #[default(false)]
+    pub different: bool,
+    pub bitstream: Vec<u8>,
+    #[default(0)]
+    pub handle: u32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SelectSkill {
-	#[default(false)]
-	pub from_skill_set: bool,
-	pub skill_id: i32,
+    #[default(false)]
+    pub from_skill_set: bool,
+    pub skill_id: i32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct PickupCurrency {
-	pub currency: u32,
-	pub position: Vector3,
+    pub currency: u32,
+    pub position: Vector3,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct PickupItem {
-	pub loot_object_id: ObjId,
-	pub player_id: ObjId,
+    pub loot_object_id: ObjId,
+    pub player_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct RebuildCancel {
-	pub early_release: bool,
-	pub user_id: ObjId,
+    pub early_release: bool,
+    pub user_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct RespondToMission {
-	pub mission_id: i32,
-	pub player_id: ObjId,
-	pub receiver: ObjId,
-	#[default(LOT_NULL)]
-	pub reward_item: Lot,
+    pub mission_id: i32,
+    pub player_id: ObjId,
+    pub receiver: ObjId,
+    #[default(LOT_NULL)]
+    pub reward_item: Lot,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ServerTerminateInteraction {
-	pub obj_id_terminator: ObjId,
-	pub terminate_type: TerminateType,
+    pub obj_id_terminator: ObjId,
+    pub terminate_type: TerminateType,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum TerminateType {
-	Range,
-	User,
-	FromInteraction,
+    Range,
+    User,
+    FromInteraction,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct RequestUse {
-	pub is_multi_interact_use: bool,
-	pub multi_interact_id: u32,
-	pub multi_interact_type: InteractionType,
-	pub object: ObjId,
-	#[default(false)]
-	pub secondary: bool,
+    pub is_multi_interact_use: bool,
+    pub multi_interact_id: u32,
+    pub multi_interact_type: InteractionType,
+    pub object: ObjId,
+    #[default(false)]
+    pub secondary: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum InteractionType {
-	MissionOfferer,
-	Vendor,
-	ItemRecipe,
-	ItemForge,
-	Script = 999,
+    MissionOfferer,
+    Vendor,
+    ItemRecipe,
+    ItemForge,
+    Script = 999,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct BuyFromVendor {
-	#[default(false)]
-	pub confirmed: bool,
-	#[default(1)]
-	pub count: i32, // todo: unsigned?
-	pub item: Lot,
+    #[default(false)]
+    pub confirmed: bool,
+    #[default(1)]
+    pub count: i32, // todo: unsigned?
+    pub item: Lot,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SellToVendor {
-	#[default(1)]
-	pub count: i32, // todo: unsigned?
-	pub item_obj_id: ObjId,
+    #[default(1)]
+    pub count: i32, // todo: unsigned?
+    pub item_obj_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct AcknowledgePossession {
-	#[default(OBJID_EMPTY)]
-	pub possessed_obj_id: ObjId,
+    #[default(OBJID_EMPTY)]
+    pub possessed_obj_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct RequestActivityExit {
-	pub user_cancel: bool,
-	pub user_id: ObjId,
+    pub user_cancel: bool,
+    pub user_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ShootingGalleryFire {
-	pub target_pos: Vector3,
-	pub w: f32,
-	pub x: f32,
-	pub y: f32,
-	pub z: f32,
+    pub target_pos: Vector3,
+    pub w: f32,
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ClientItemConsumed {
-	pub item: ObjId,
+    pub item: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct UpdateShootingGalleryRotation {
-	pub angle: f32,
-	pub facing: Vector3,
-	pub muzzle_pos: Vector3,
+    pub angle: f32,
+    pub facing: Vector3,
+    pub muzzle_pos: Vector3,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetTooltipFlag {
-	pub flag: bool,
-	pub tool_tip: i32,
+    pub flag: bool,
+    pub tool_tip: i32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetFlag {
-	pub flag: bool,
-	pub flag_id: i32,
+    pub flag: bool,
+    pub flag_id: i32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct HasBeenCollected {
-	pub player_id: ObjId,
+    pub player_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct DespawnPet {
-	pub delete_pet: bool,
+    pub delete_pet: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct PlayerLoaded {
-	pub player_id: ObjId,
+    pub player_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct RequestLinkedMission {
-	pub player_id: ObjId,
-	pub mission_id: i32,
-	pub mission_offered: bool,
+    pub player_id: ObjId,
+    pub mission_id: i32,
+    pub mission_offered: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct MissionDialogueOk {
-	pub is_complete: bool,
-	pub mission_state: MissionState,
-	pub mission_id: i32,
-	pub responder: ObjId,
+    pub is_complete: bool,
+    pub mission_state: MissionState,
+    pub mission_id: i32,
+    pub responder: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct MessageBoxRespond {
-	pub button: i32,
-	pub identifier: GmWString,
-	pub user_data: GmWString,
+    pub button: i32,
+    pub identifier: GmWString,
+    pub user_data: GmWString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ChoiceBoxRespond {
-	pub button_identifier: GmWString,
-	pub button: i32,
-	pub identifier: GmWString,
+    pub button_identifier: GmWString,
+    pub button: i32,
+    pub identifier: GmWString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct UseNonEquipmentItem {
-	pub item_to_use: ObjId,
+    pub item_to_use: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct FetchModelMetadataRequest {
-	pub context: i32,
-	pub object_id: ObjId,
-	pub requestor_id: ObjId,
-	pub ug_id: ObjId,
+    pub context: i32,
+    pub object_id: ObjId,
+    pub requestor_id: ObjId,
+    pub ug_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct CommandPet {
-	pub generic_pos_info: Vector3,
-	pub obj_id_source: ObjId,
-	pub pet_command_type: i32,
-	pub type_id: i32,
-	#[default(false)]
-	pub override_obey: bool,
+    pub generic_pos_info: Vector3,
+    pub obj_id_source: ObjId,
+    pub pet_command_type: i32,
+    pub type_id: i32,
+    #[default(false)]
+    pub override_obey: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct RequestActivitySummaryLeaderboardData {
-	#[default(0)]
-	pub game_id: i32,
-	#[default(QueryType::TopCharacter)]
-	pub query_type: QueryType,
-	#[default(10)]
-	pub results_end: i32,
-	#[default(0)]
-	pub results_start: i32,
-	pub target: ObjId,
-	pub weekly: bool,
+    #[default(0)]
+    pub game_id: i32,
+    #[default(QueryType::TopCharacter)]
+    pub query_type: QueryType,
+    #[default(10)]
+    pub results_end: i32,
+    #[default(0)]
+    pub results_start: i32,
+    pub target: ObjId,
+    pub weekly: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct NotifyPet {
-	pub obj_id_source: ObjId,
-	pub obj_to_notify_pet_about: ObjId,
-	pub pet_notification_type: PetNotificationType,
+    pub obj_id_source: ObjId,
+    pub obj_to_notify_pet_about: ObjId,
+    pub pet_notification_type: PetNotificationType,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum QueryType {
-	TopAll,
-	TopCharacter,
-	TopSocial,
+    TopAll,
+    TopCharacter,
+    TopSocial,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ClientExitTamingMinigame {
-	#[default(true)]
-	pub voluntary_exit: bool,
+    #[default(true)]
+    pub voluntary_exit: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct PetTamingMinigameResult {
-	pub success: bool,
+    pub success: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct NotifyTamingBuildSuccess {
-	pub build_position: Vector3,
+    pub build_position: Vector3,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct RequestSetPetName {
-	pub name: GmWString,
+    pub name: GmWString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct CinematicUpdate {
-	#[default(CinematicEvent::Started)]
-	pub event: CinematicEvent,
-	#[default(-1.0)]
-	pub overall_time: f32,
-	pub path_name: GmWString,
-	#[default(-1.0)]
-	pub path_time: f32,
-	#[default(-1)]
-	pub waypoint: i32,
+    #[default(CinematicEvent::Started)]
+    pub event: CinematicEvent,
+    #[default(-1.0)]
+    pub overall_time: f32,
+    pub path_name: GmWString,
+    #[default(-1.0)]
+    pub path_time: f32,
+    #[default(-1)]
+    pub waypoint: i32,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum CinematicEvent {
-	Started,
-	Waypoint,
-	Ended,
+    Started,
+    Waypoint,
+    Ended,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct FireEventServerSide {
-	pub args: GmWString,
-	#[default(-1)]
-	pub param1: i32,
-	#[default(-1)]
-	pub param2: i32,
-	#[default(-1)]
-	pub param3: i32,
-	pub sender_id: ObjId,
+    pub args: GmWString,
+    #[default(-1)]
+    pub param1: i32,
+    #[default(-1)]
+    pub param2: i32,
+    #[default(-1)]
+    pub param3: i32,
+    pub sender_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct PropertyEditorBegin {
-	#[default(0)]
-	pub distance_type: i32,
-	#[default(OBJID_EMPTY)]
-	pub property_object_id: ObjId,
-	#[default(1)]
-	pub start_mode: i32,
-	#[default(0)]
-	pub start_paused: bool,
+    #[default(0)]
+    pub distance_type: i32,
+    #[default(OBJID_EMPTY)]
+    pub property_object_id: ObjId,
+    #[default(1)]
+    pub start_mode: i32,
+    #[default(0)]
+    pub start_paused: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ToggleGhostReferenceOverride {
-	#[default(false)]
-	pub ref_override: bool,
+    #[default(false)]
+    pub ref_override: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetGhostReferencePosition {
-	pub pos: Vector3,
+    pub pos: Vector3,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct UpdateModelFromClient {
-	pub model_id: ObjId,
-	pub position: Vector3,
-	#[default(Quaternion::IDENTITY)]
-	pub rotation: Quaternion,
+    pub model_id: ObjId,
+    pub position: Vector3,
+    #[default(Quaternion::IDENTITY)]
+    pub rotation: Quaternion,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct DeleteModelFromClient {
-	#[default(OBJID_EMPTY)]
-	pub model_id: ObjId,
-	#[default(DeleteReason::PickingModelUp)]
-	pub reason: DeleteReason,
+    #[default(OBJID_EMPTY)]
+    pub model_id: ObjId,
+    #[default(DeleteReason::PickingModelUp)]
+    pub reason: DeleteReason,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum DeleteReason {
-	PickingModelUp,
-	ReturningModelToInventory,
-	BreakingModelApart,
+    PickingModelUp,
+    ReturningModelToInventory,
+    BreakingModelApart,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct EnterProperty1 {
-	pub index: i32,
-	#[default(true)]
-	pub return_to_zone: bool,
+    pub index: i32,
+    #[default(true)]
+    pub return_to_zone: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct PropertyEntranceSync {
-	pub include_null_address: bool,
-	pub include_null_description: bool,
-	pub players_own: bool,
-	pub update_ui: bool,
-	pub num_results: i32,
-	pub reputation_time: i32,
-	pub sort_method: i32,
-	pub start_index: i32,
-	pub filter_text: GmString,
+    pub include_null_address: bool,
+    pub include_null_description: bool,
+    pub players_own: bool,
+    pub update_ui: bool,
+    pub num_results: i32,
+    pub reputation_time: i32,
+    pub sort_method: i32,
+    pub start_index: i32,
+    pub filter_text: GmString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ParseChatMessage {
-	pub client_state: i32,
-	pub string: GmWString,
+    pub client_state: i32,
+    pub string: GmWString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetMissionTypeState {
-	#[default(MissionLockState::New)]
-	pub state: MissionLockState,
-	pub mission_subtype: GmString,
-	pub mission_type: GmString,
+    #[default(MissionLockState::New)]
+    pub state: MissionLockState,
+    pub mission_subtype: GmString,
+    pub mission_type: GmString,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum MissionLockState {
-	Locked,
-	New,
-	Unlocked,
+    Locked,
+    New,
+    Unlocked,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ClientTradeRequest {
-	#[default(false)]
-	pub need_invite_pop_up: bool,
-	pub invitee: ObjId,
+    #[default(false)]
+    pub need_invite_pop_up: bool,
+    pub invitee: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ClientTradeAccept {
-	#[default(false)]
-	pub first: bool,
+    #[default(false)]
+    pub first: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ReadyForUpdates {
-	pub object_id: ObjId,
+    pub object_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetLastCustomBuild {
-	pub tokenized_lot_list: GmWString,
+    pub tokenized_lot_list: GmWString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct PropertyModerationAction {
-	#[default(0)]
-	pub character_id: ObjId,
-	pub info: GmWString,
-	#[default(-1)]
-	pub new_moderation_status: i32,
+    #[default(0)]
+    pub character_id: ObjId,
+    pub info: GmWString,
+    #[default(-1)]
+    pub new_moderation_status: i32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct BounceNotification {
-	pub obj_id_bounced: ObjId,
-	pub obj_id_bouncer: ObjId,
-	pub success: bool,
+    pub obj_id_bounced: ObjId,
+    pub obj_id_bouncer: ObjId,
+    pub success: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetBbbAutosave {
-	pub lxfml_data_compressed: Vec<u8>,
+    pub lxfml_data_compressed: Vec<u8>,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct BbbLoadItemRequest {
-	pub item_id: ObjId,
+    pub item_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct BbbSaveRequest {
-	pub local_id: ObjId,
-	pub lxfml_data_compressed: Vec<u8>,
-	pub time_taken_in_ms: u32,
+    pub local_id: ObjId,
+    pub lxfml_data_compressed: Vec<u8>,
+    pub time_taken_in_ms: u32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ZoneSummaryDismissed {
-	pub player_id: ObjId,
+    pub player_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ActivityStateChangeRequest {
-	pub obj_id: ObjId,
-	pub num_value_1: i32,
-	pub num_value_2: i32,
-	pub string_value: GmWString,
+    pub obj_id: ObjId,
+    pub num_value_1: i32,
+    pub num_value_2: i32,
+    pub string_value: GmWString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct StartBuildingWithItem {
-	#[default(true)]
-	pub first_time: bool,
-	pub success: bool,
-	pub source_bag: InventoryType,
-	pub source_id: ObjId,
-	pub source_lot: Lot,
-	pub source_type: i32,
-	pub target_id: ObjId,
-	pub target_lot: Lot,
-	pub target_pos: Vector3,
-	pub target_type: i32,
+    #[default(true)]
+    pub first_time: bool,
+    pub success: bool,
+    pub source_bag: InventoryType,
+    pub source_id: ObjId,
+    pub source_lot: Lot,
+    pub source_type: i32,
+    pub target_id: ObjId,
+    pub target_lot: Lot,
+    pub target_pos: Vector3,
+    pub target_type: i32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct DoneArrangingWithItem {
-	pub new_source_bag: InventoryType,
-	pub new_source_id: ObjId,
-	pub new_source_lot: Lot,
-	pub new_source_type: i32,
-	pub new_target_id: ObjId,
-	pub new_target_lot: Lot,
-	pub new_target_type: i32,
-	pub new_target_pos: Vector3,
-	pub old_item_bag: InventoryType,
-	pub old_item_id: ObjId,
-	pub old_item_lot: Lot,
-	pub old_item_type: i32,
+    pub new_source_bag: InventoryType,
+    pub new_source_id: ObjId,
+    pub new_source_lot: Lot,
+    pub new_source_type: i32,
+    pub new_target_id: ObjId,
+    pub new_target_lot: Lot,
+    pub new_target_type: i32,
+    pub new_target_pos: Vector3,
+    pub old_item_bag: InventoryType,
+    pub old_item_id: ObjId,
+    pub old_item_lot: Lot,
+    pub old_item_type: i32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetBuildMode {
-	pub start: bool,
-	#[default(-1)]
-	pub distance_type: i32,
-	#[default(false)]
-	pub mode_paused: bool,
-	#[default(1)]
-	pub mode_value: i32,
-	pub player_id: ObjId,
-	#[default(Vector3::ZERO)]
-	pub start_pos: Vector3,
+    pub start: bool,
+    #[default(-1)]
+    pub distance_type: i32,
+    #[default(false)]
+    pub mode_paused: bool,
+    #[default(1)]
+    pub mode_value: i32,
+    pub player_id: ObjId,
+    #[default(Vector3::ZERO)]
+    pub start_pos: Vector3,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct BuildModeSet {
-	pub start: bool,
-	#[default(-1)]
-	pub distance_type: i32,
-	#[default(false)]
-	pub mode_paused: bool,
-	#[default(1)]
-	pub mode_value: i32,
-	pub player_id: ObjId,
-	#[default(Vector3::ZERO)]
-	pub start_pos: Vector3,
+    pub start: bool,
+    #[default(-1)]
+    pub distance_type: i32,
+    #[default(false)]
+    pub mode_paused: bool,
+    #[default(1)]
+    pub mode_value: i32,
+    pub player_id: ObjId,
+    #[default(Vector3::ZERO)]
+    pub start_pos: Vector3,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct BuildExitConfirmation {
-	pub player_id: ObjId,
+    pub player_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct MoveItemBetweenInventoryTypes {
-	pub inventory_type_a: InventoryType,
-	pub inventory_type_b: InventoryType,
-	pub object_id: ObjId,
-	#[default(true)]
-	pub show_flying_loot: bool,
-	#[default(1)]
-	pub stack_count: u32,
-	#[default(LOT_NULL)]
-	pub template_id: Lot,
+    pub inventory_type_a: InventoryType,
+    pub inventory_type_b: InventoryType,
+    pub object_id: ObjId,
+    #[default(true)]
+    pub show_flying_loot: bool,
+    #[default(1)]
+    pub stack_count: u32,
+    #[default(LOT_NULL)]
+    pub template_id: Lot,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct MissionDialogueCancelled {
-	pub is_complete: bool,
-	pub mission_state: MissionState,
-	pub mission_id: i32,
-	pub responder: ObjId,
+    pub is_complete: bool,
+    pub mission_state: MissionState,
+    pub mission_id: i32,
+    pub responder: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SyncSkill {
-	#[default(false)]
-	pub done: bool,
-	pub bitstream: Vec<u8>,
-	pub behavior_handle: u32,
-	pub skill_handle: u32,
+    #[default(false)]
+    pub done: bool,
+    pub bitstream: Vec<u8>,
+    pub behavior_handle: u32,
+    pub skill_handle: u32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct RequestServerProjectileImpact {
-	#[default(OBJID_EMPTY)]
-	pub local_id: ObjId,
-	#[default(OBJID_EMPTY)]
-	pub target_id: ObjId,
-	pub bitstream: Vec<u8>,
+    #[default(OBJID_EMPTY)]
+    pub local_id: ObjId,
+    #[default(OBJID_EMPTY)]
+    pub target_id: ObjId,
+    pub bitstream: Vec<u8>,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ToggleSendingPositionUpdates {
-	#[default(false)]
-	pub send_updates: bool,
+    #[default(false)]
+    pub send_updates: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct PlacePropertyModel {
-	pub model_id: ObjId,
+    pub model_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ReportBug {
-	pub body: GmWString,
-	pub client_version: GmString,
-	pub other_player_id: GmString,
-	pub selection: GmString,
+    pub body: GmWString,
+    pub client_version: GmString,
+    pub other_player_id: GmString,
+    pub selection: GmString,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct RacingPlayerInfoResetFinished {
-	pub player_id: ObjId,
+    pub player_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct VehicleSetWheelLockState {
-	#[default(true)]
-	pub extra_friction: bool,
-	#[default(false)]
-	pub locked: bool,
+    #[default(true)]
+    pub extra_friction: bool,
+    #[default(false)]
+    pub locked: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct PropertyContentsFromClient {
-	#[default(false)]
-	pub query_db: bool,
+    #[default(false)]
+    pub query_db: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ZonePropertyModelRotated {
-	#[default(OBJID_EMPTY)]
-	pub player_id: ObjId,
-	#[default(OBJID_EMPTY)]
-	pub property_id: ObjId,
+    #[default(OBJID_EMPTY)]
+    pub player_id: ObjId,
+    #[default(OBJID_EMPTY)]
+    pub property_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ZonePropertyModelRemovedWhileEquipped {
-	#[default(OBJID_EMPTY)]
-	pub player_id: ObjId,
-	#[default(OBJID_EMPTY)]
-	pub property_id: ObjId,
+    #[default(OBJID_EMPTY)]
+    pub player_id: ObjId,
+    #[default(OBJID_EMPTY)]
+    pub property_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ZonePropertyModelEquipped {
-	#[default(OBJID_EMPTY)]
-	pub player_id: ObjId,
-	#[default(OBJID_EMPTY)]
-	pub property_id: ObjId,
+    #[default(OBJID_EMPTY)]
+    pub player_id: ObjId,
+    #[default(OBJID_EMPTY)]
+    pub property_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct RacingClientReady {
-	pub player_id: ObjId,
+    pub player_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ResetPropertyBehaviors {
-	#[default(true)]
-	pub force: bool,
-	#[default(false)]
-	pub pause: bool,
+    #[default(true)]
+    pub force: bool,
+    #[default(false)]
+    pub pause: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetConsumableItem {
-	pub item_template_id: Lot,
+    pub item_template_id: Lot,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct UsedInformationPlaque {
-	pub plaque: ObjId,
+    pub plaque: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ActivateBrickMode {
-	#[default(OBJID_EMPTY)]
-	pub build_object_id: ObjId,
-	#[default(BuildType::OnProperty)]
-	pub build_type: BuildType,
-	#[default(true)]
-	pub enter_build_from_world: bool,
-	#[default(true)]
-	pub enter_flag: bool,
+    #[default(OBJID_EMPTY)]
+    pub build_object_id: ObjId,
+    #[default(BuildType::OnProperty)]
+    pub build_type: BuildType,
+    #[default(true)]
+    pub enter_build_from_world: bool,
+    #[default(true)]
+    pub enter_flag: bool,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 #[repr(u32)]
 pub enum BuildType {
-	Nowhere,
-	InWorld,
-	OnProperty,
+    Nowhere,
+    InWorld,
+    OnProperty,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct CancelRailMovement {
-	#[default(false)]
-	pub immediate: bool,
+    #[default(false)]
+    pub immediate: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct PlayerRailArrivedNotification {
-	pub path_name: GmWString,
-	pub waypoint_number: i32,
+    pub path_name: GmWString,
+    pub waypoint_number: i32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ModifyGhostingDistance {
-	#[default(1.0)]
-	pub distance: f32,
+    #[default(1.0)]
+    pub distance: f32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct ModularAssemblyNifCompleted {
-	pub object_id: ObjId,
+    pub object_id: ObjId,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct UpdatePropertyPerformanceCost {
-	#[default(0.0)]
-	pub performance_cost: f32,
+    #[default(0.0)]
+    pub performance_cost: f32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SetEmotesEnabled {
-	#[default(true)]
-	pub enable_emotes: bool,
+    #[default(true)]
+    pub enable_emotes: bool,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct VehicleNotifyHitImaginationServer {
-	#[default(OBJID_EMPTY)]
-	pub pickup_obj_id: ObjId,
-	#[default(OBJID_EMPTY)]
-	pub pickup_spawner_id: ObjId,
-	#[default(-1)]
-	pub pickup_spawner_index: i32,
-	#[default(Vector3::ZERO)]
-	pub vehicle_position: Vector3,
+    #[default(OBJID_EMPTY)]
+    pub pickup_obj_id: ObjId,
+    #[default(OBJID_EMPTY)]
+    pub pickup_spawner_id: ObjId,
+    #[default(-1)]
+    pub pickup_spawner_index: i32,
+    #[default(Vector3::ZERO)]
+    pub vehicle_position: Vector3,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct RequestMoveItemBetweenInventoryTypes {
-	#[default(true)]
-	pub allow_partial: bool,
-	#[default(-1)]
-	pub dest_slot: i32,
-	#[default(1)]
-	pub stack_count: u32,
-	#[default(InventoryType::Default)]
-	pub inv_type_dst: InventoryType,
-	#[default(InventoryType::Default)]
-	pub inv_type_src: InventoryType,
-	#[default(OBJID_EMPTY)]
-	pub object_id: ObjId,
-	#[default(true)]
-	pub show_flying_loot: bool,
-	#[default(OBJID_EMPTY)]
-	pub subkey: ObjId,
-	#[default(LOT_NULL)]
-	pub template_id: Lot,
+    #[default(true)]
+    pub allow_partial: bool,
+    #[default(-1)]
+    pub dest_slot: i32,
+    #[default(1)]
+    pub stack_count: u32,
+    #[default(InventoryType::Default)]
+    pub inv_type_dst: InventoryType,
+    #[default(InventoryType::Default)]
+    pub inv_type_src: InventoryType,
+    #[default(OBJID_EMPTY)]
+    pub object_id: ObjId,
+    #[default(true)]
+    pub show_flying_loot: bool,
+    #[default(OBJID_EMPTY)]
+    pub subkey: ObjId,
+    #[default(LOT_NULL)]
+    pub template_id: Lot,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct DismountComplete {
-	pub mount_id: ObjId,
+    pub mount_id: ObjId,
 }

--- a/src/world/lnv.rs
+++ b/src/world/lnv.rs
@@ -1,13 +1,13 @@
 //! LU name value datatype.
 use std::collections::HashMap;
 use std::convert::{TryFrom, TryInto};
-use std::io::{Read, Write};
 use std::io::Result as Res;
+use std::io::{Read, Write};
 
-use flate2::{Compression, read::ZlibDecoder, write::ZlibEncoder};
+use flate2::{read::ZlibDecoder, write::ZlibEncoder, Compression};
 
-use endio::{Deserialize, LE, LERead, LEWrite, Serialize};
 use super::gm::GmParam;
+use endio::{Deserialize, LERead, LEWrite, Serialize, LE};
 
 use crate::common::{LuStrExt, LuVarString, LuVarWString, LuWStr};
 
@@ -15,95 +15,117 @@ use crate::common::{LuStrExt, LuVarString, LuVarWString, LuWStr};
 #[derive(Deserialize, PartialEq, Serialize)]
 #[repr(u8)]
 pub enum LnvValue {
-	WString(LuVarWString<u32>) = 0,
-	I32(i32) = 1,
-	F32(f32) = 3,
-	F64(f64) = 4,
-	U32(u32) = 5,
-	Bool(bool) = 7,
-	I64(i64) = 8,
-	U64(u64) = 9,
-	String(LuVarString<u32>) = 13,
+    WString(LuVarWString<u32>) = 0,
+    I32(i32) = 1,
+    F32(f32) = 3,
+    F64(f64) = 4,
+    U32(u32) = 5,
+    Bool(bool) = 7,
+    I64(i64) = 8,
+    U64(u64) = 9,
+    String(LuVarString<u32>) = 13,
 }
 
 impl LnvValue {
-	fn parse_ty_val(wstr: &LuWStr) -> Self {
-		let string: String = wstr.to_string();
-		let (ty, val) = string.split_at(string.find(":").unwrap());
-		let val = val.split_at(1).1;
-		match ty {
-			"0"  => LnvValue::WString(val.try_into().unwrap()),
-			"1"  => LnvValue::I32(val.parse().unwrap()),
-			"3"  => LnvValue::F32(val.parse().unwrap()),
-			"4"  => LnvValue::F64(val.parse().unwrap()),
-			"5"  => LnvValue::U32(val.parse().unwrap()),
-			"7"  => LnvValue::Bool(val == "1"),
-			"8"  => LnvValue::I64(val.parse().unwrap()),
-			"9"  => LnvValue::U64(val.parse().unwrap()),
-			"13" => LnvValue::String(val.as_bytes().try_into().unwrap()),
-			_ => panic!(),
-		}
-	}
+    fn parse_ty_val(wstr: &LuWStr) -> Self {
+        let string: String = wstr.to_string();
+        let (ty, val) = string.split_at(string.find(":").unwrap());
+        let val = val.split_at(1).1;
+        match ty {
+            "0" => LnvValue::WString(val.try_into().unwrap()),
+            "1" => LnvValue::I32(val.parse().unwrap()),
+            "3" => LnvValue::F32(val.parse().unwrap()),
+            "4" => LnvValue::F64(val.parse().unwrap()),
+            "5" => LnvValue::U32(val.parse().unwrap()),
+            "7" => LnvValue::Bool(val == "1"),
+            "8" => LnvValue::I64(val.parse().unwrap()),
+            "9" => LnvValue::U64(val.parse().unwrap()),
+            "13" => LnvValue::String(val.as_bytes().try_into().unwrap()),
+            _ => panic!(),
+        }
+    }
 }
 
 impl std::fmt::Debug for LnvValue {
-	fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-		match self {
-			LnvValue::WString(x) => write!(f, "{:?}", x),
-			LnvValue::I32    (x) => write!(f, "{:?}i32", x),
-			LnvValue::F32    (x) => write!(f, "{:?}f32", x),
-			LnvValue::F64    (x) => write!(f, "{:?}f64", x),
-			LnvValue::U32    (x) => write!(f, "{:?}u32", x),
-			LnvValue::Bool   (x) => write!(f, "{:?}", x),
-			LnvValue::I64    (x) => write!(f, "{:?}i64", x),
-			LnvValue::U64    (x) => write!(f, "{:?}u64", x),
-			LnvValue::String (x) => write!(f, "{:?}", x),
-		}
-	}
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        match self {
+            LnvValue::WString(x) => write!(f, "{:?}", x),
+            LnvValue::I32(x) => write!(f, "{:?}i32", x),
+            LnvValue::F32(x) => write!(f, "{:?}f32", x),
+            LnvValue::F64(x) => write!(f, "{:?}f64", x),
+            LnvValue::U32(x) => write!(f, "{:?}u32", x),
+            LnvValue::Bool(x) => write!(f, "{:?}", x),
+            LnvValue::I64(x) => write!(f, "{:?}i64", x),
+            LnvValue::U64(x) => write!(f, "{:?}u64", x),
+            LnvValue::String(x) => write!(f, "{:?}", x),
+        }
+    }
 }
 
 impl From<LuVarWString<u32>> for LnvValue {
-	fn from(val: LuVarWString<u32>) -> Self { LnvValue::WString(val) }
+    fn from(val: LuVarWString<u32>) -> Self {
+        LnvValue::WString(val)
+    }
 }
 
 impl From<&str> for LnvValue {
-	fn from(val: &str) -> Self { LnvValue::WString(val.try_into().unwrap()) }
+    fn from(val: &str) -> Self {
+        LnvValue::WString(val.try_into().unwrap())
+    }
 }
 
 impl From<i32> for LnvValue {
-	fn from(val: i32) -> Self { LnvValue::I32(val) }
+    fn from(val: i32) -> Self {
+        LnvValue::I32(val)
+    }
 }
 
 impl From<f32> for LnvValue {
-	fn from(val: f32) -> Self { LnvValue::F32(val) }
+    fn from(val: f32) -> Self {
+        LnvValue::F32(val)
+    }
 }
 
 impl From<f64> for LnvValue {
-	fn from(val: f64) -> Self { LnvValue::F64(val) }
+    fn from(val: f64) -> Self {
+        LnvValue::F64(val)
+    }
 }
 
 impl From<u32> for LnvValue {
-	fn from(val: u32) -> Self { LnvValue::U32(val) }
+    fn from(val: u32) -> Self {
+        LnvValue::U32(val)
+    }
 }
 
 impl From<bool> for LnvValue {
-	fn from(val: bool) -> Self { LnvValue::Bool(val) }
+    fn from(val: bool) -> Self {
+        LnvValue::Bool(val)
+    }
 }
 
 impl From<i64> for LnvValue {
-	fn from(val: i64) -> Self { LnvValue::I64(val) }
+    fn from(val: i64) -> Self {
+        LnvValue::I64(val)
+    }
 }
 
 impl From<u64> for LnvValue {
-	fn from(val: u64) -> Self { LnvValue::U64(val) }
+    fn from(val: u64) -> Self {
+        LnvValue::U64(val)
+    }
 }
 
 impl From<&[u8]> for LnvValue {
-	fn from(val: &[u8]) -> Self { LnvValue::String(val.try_into().unwrap()) }
+    fn from(val: &[u8]) -> Self {
+        LnvValue::String(val.try_into().unwrap())
+    }
 }
 
 impl<const N: usize> From<&[u8; N]> for LnvValue {
-	fn from(val: &[u8; N]) -> Self { LnvValue::String(val.try_into().unwrap()) }
+    fn from(val: &[u8; N]) -> Self {
+        LnvValue::String(val.try_into().unwrap())
+    }
 }
 
 /// A hash map with values being one of multiple possible types.
@@ -111,166 +133,173 @@ impl<const N: usize> From<&[u8; N]> for LnvValue {
 pub struct LuNameValue(HashMap<LuVarWString<u32>, LnvValue>);
 
 impl LuNameValue {
-	pub fn new() -> Self {
-		LuNameValue(HashMap::new())
-	}
+    pub fn new() -> Self {
+        LuNameValue(HashMap::new())
+    }
 }
 
 impl std::ops::Deref for LuNameValue {
-	type Target = HashMap<LuVarWString<u32>, LnvValue>;
+    type Target = HashMap<LuVarWString<u32>, LnvValue>;
 
-	#[inline]
-	fn deref(&self) -> &Self::Target {
-		&self.0
-	}
+    #[inline]
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
 }
 
 impl std::ops::DerefMut for LuNameValue {
-	#[inline]
-	fn deref_mut(&mut self) -> &mut Self::Target {
-		&mut self.0
-	}
+    #[inline]
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
 }
 
 impl std::fmt::Debug for LuNameValue {
-	fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
-		write!(f, "lnv! ")?;
-		f.debug_map().entries(self.0.iter().map(|(k, v)| (k, v))).finish()
-	}
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
+        write!(f, "lnv! ")?;
+        f.debug_map()
+            .entries(self.0.iter().map(|(k, v)| (k, v)))
+            .finish()
+    }
 }
 
 impl<R: Read> Deserialize<LE, R> for LuNameValue {
-	fn deserialize(reader: &mut R) -> Res<Self> {
-		let len: u32 = LERead::read(reader)?;
-		let is_compressed: bool = LERead::read(reader)?;
-		let uncompressed = if is_compressed {
-			let uncomp_len: u32 = LERead::read(reader)?;
-			let comp_len: u32 = LERead::read(reader)?;
-			let mut comp = vec![0; comp_len as usize];
-			reader.read_exact(&mut comp)?;
-			let mut inflater = ZlibDecoder::new(&comp[..]);
-			let mut uncomp = Vec::with_capacity(uncomp_len as usize);
-			inflater.read_to_end(&mut uncomp)?;
-			assert_eq!(uncomp.len(), uncomp_len as usize);
-			uncomp
-		} else {
-			let mut uncomp = vec![0; len as usize -1];
-			reader.read_exact(&mut uncomp)?;
-			uncomp
-		};
-		let unc_reader = &mut &uncompressed[..];
-		let lnv_len: u32 = LERead::read(unc_reader)?;
-		let mut res = lnv!();
-		for _ in 0..lnv_len {
-			let enc_key_len: u8 = LERead::read(unc_reader)?;
-			let key = LuVarWString::deser_content(unc_reader, enc_key_len as u32 / 2)?;
-			let value = LERead::read(unc_reader)?;
-			res.insert(key, value);
-		}
-		Ok(res)
-	}
+    fn deserialize(reader: &mut R) -> Res<Self> {
+        let len: u32 = LERead::read(reader)?;
+        let is_compressed: bool = LERead::read(reader)?;
+        let uncompressed = if is_compressed {
+            let uncomp_len: u32 = LERead::read(reader)?;
+            let comp_len: u32 = LERead::read(reader)?;
+            let mut comp = vec![0; comp_len as usize];
+            reader.read_exact(&mut comp)?;
+            let mut inflater = ZlibDecoder::new(&comp[..]);
+            let mut uncomp = Vec::with_capacity(uncomp_len as usize);
+            inflater.read_to_end(&mut uncomp)?;
+            assert_eq!(uncomp.len(), uncomp_len as usize);
+            uncomp
+        } else {
+            let mut uncomp = vec![0; len as usize - 1];
+            reader.read_exact(&mut uncomp)?;
+            uncomp
+        };
+        let unc_reader = &mut &uncompressed[..];
+        let lnv_len: u32 = LERead::read(unc_reader)?;
+        let mut res = lnv!();
+        for _ in 0..lnv_len {
+            let enc_key_len: u8 = LERead::read(unc_reader)?;
+            let key = LuVarWString::deser_content(unc_reader, enc_key_len as u32 / 2)?;
+            let value = LERead::read(unc_reader)?;
+            res.insert(key, value);
+        }
+        Ok(res)
+    }
 }
 
 impl<'a, W: Write> Serialize<LE, W> for &'a LuNameValue {
-	fn serialize(self, writer: &mut W) -> Res<()> {
-		let mut uncompressed: Vec<u8> = vec![];
-		LEWrite::write(&mut uncompressed, self.len() as u32)?;
-		#[cfg(test)]
-		let key_value = {
-			let mut key_value: Vec<_> = self.0.iter().collect();
-			key_value.sort_unstable_by(|(k1, _), (k2, _)| k1.cmp(k2));
-			key_value
-		};
-		#[cfg(not(test))]
-		let key_value = self.0.iter();
-		for (key, value) in key_value {
-			LEWrite::write(&mut uncompressed, key.len() as u8 * 2)?;
-			key.ser_content(&mut uncompressed)?;
-			LEWrite::write(&mut uncompressed, value)?;
-		}
-		let is_compressed = true;
-		if !is_compressed {
-			LEWrite::write(writer, uncompressed.len() as u32 + 1)?;
-			LEWrite::write(writer, false)?;
-			writer.write_all(&uncompressed)?;
-		} else {
-			let mut compressed = vec![];
-			ZlibEncoder::new(&mut compressed, Compression::new(6)).write_all(&uncompressed)?;
-			LEWrite::write(writer, compressed.len() as u32 + 1 + 4 + 4)?;
-			LEWrite::write(writer, true)?;
-			LEWrite::write(writer, uncompressed.len() as u32)?;
-			LEWrite::write(writer, compressed.len() as u32)?;
-			writer.write_all(&compressed)?;
-		}
-		Ok(())
-	}
+    fn serialize(self, writer: &mut W) -> Res<()> {
+        let mut uncompressed: Vec<u8> = vec![];
+        LEWrite::write(&mut uncompressed, self.len() as u32)?;
+        #[cfg(test)]
+        let key_value = {
+            let mut key_value: Vec<_> = self.0.iter().collect();
+            key_value.sort_unstable_by(|(k1, _), (k2, _)| k1.cmp(k2));
+            key_value
+        };
+        #[cfg(not(test))]
+        let key_value = self.0.iter();
+        for (key, value) in key_value {
+            LEWrite::write(&mut uncompressed, key.len() as u8 * 2)?;
+            key.ser_content(&mut uncompressed)?;
+            LEWrite::write(&mut uncompressed, value)?;
+        }
+        let is_compressed = true;
+        if !is_compressed {
+            LEWrite::write(writer, uncompressed.len() as u32 + 1)?;
+            LEWrite::write(writer, false)?;
+            writer.write_all(&uncompressed)?;
+        } else {
+            let mut compressed = vec![];
+            ZlibEncoder::new(&mut compressed, Compression::new(6)).write_all(&uncompressed)?;
+            LEWrite::write(writer, compressed.len() as u32 + 1 + 4 + 4)?;
+            LEWrite::write(writer, true)?;
+            LEWrite::write(writer, uncompressed.len() as u32)?;
+            LEWrite::write(writer, compressed.len() as u32)?;
+            writer.write_all(&compressed)?;
+        }
+        Ok(())
+    }
 }
 
 impl From<&LuVarWString<u32>> for LuNameValue {
-	fn from(wstr: &LuVarWString<u32>) -> Self {
-		if wstr.is_empty() {
-			return LuNameValue(HashMap::new())
-		}
-		let mut map = HashMap::new();
-		for name_type_val in wstr.split(|c| *c == b'\n'.into()) {
-			let (name, type_val) = name_type_val.split_at(name_type_val.iter().position(|c| *c == b'='.into()).unwrap());
-			let name: LuVarWString<u32> = name.into();
-			let type_val = type_val.split_at(1).1;
-			let lnv_value = LnvValue::parse_ty_val(type_val);
-			map.insert(name, lnv_value);
-		}
-		LuNameValue(map)
-	}
+    fn from(wstr: &LuVarWString<u32>) -> Self {
+        if wstr.is_empty() {
+            return LuNameValue(HashMap::new());
+        }
+        let mut map = HashMap::new();
+        for name_type_val in wstr.split(|c| *c == b'\n'.into()) {
+            let (name, type_val) = name_type_val.split_at(
+                name_type_val
+                    .iter()
+                    .position(|c| *c == b'='.into())
+                    .unwrap(),
+            );
+            let name: LuVarWString<u32> = name.into();
+            let type_val = type_val.split_at(1).1;
+            let lnv_value = LnvValue::parse_ty_val(type_val);
+            map.insert(name, lnv_value);
+        }
+        LuNameValue(map)
+    }
 }
 
 impl From<&LuNameValue> for LuVarWString<u32> {
-	fn from(lnv: &LuNameValue) -> Self {
-		let mut wstr: Self = vec![].into();
-		let mut i = 0;
-		let len = lnv.0.len();
-		let mut key_value: Vec<_> = lnv.0.iter().collect();
-		key_value.sort_unstable_by(|(k1, _), (k2, _)| k1.cmp(k2));
-		for (key, value) in key_value {
-			wstr.extend_from_slice(&key);
-			wstr.push(b'='.into());
-			let (disc, val_str) = match value {
-				LnvValue::WString(val) => ("0",  val.to_string()),
-				LnvValue::I32    (val) => ("1",  val.to_string()),
-				LnvValue::F32    (val) => ("3",  val.to_string()),
-				LnvValue::F64    (val) => ("4",  val.to_string()),
-				LnvValue::U32    (val) => ("5",  val.to_string()),
-				LnvValue::Bool   (val) => ("7",  (*val as u8).to_string()),
-				LnvValue::I64    (val) => ("8",  val.to_string()),
-				LnvValue::U64    (val) => ("9",  val.to_string()),
-				LnvValue::String (val) => ("13", val.to_string()),
-			};
-			wstr.extend_from_slice(&LuVarWString::<u32>::try_from(disc).unwrap());
-			wstr.push(b':'.into());
-			wstr.extend_from_slice(&LuVarWString::<u32>::try_from(val_str.as_str()).unwrap());
-			i += 1;
-			if i < len {
-				wstr.push(b'\n'.into());
-			}
-		}
-		wstr
-	}
+    fn from(lnv: &LuNameValue) -> Self {
+        let mut wstr: Self = vec![].into();
+        let mut i = 0;
+        let len = lnv.0.len();
+        let mut key_value: Vec<_> = lnv.0.iter().collect();
+        key_value.sort_unstable_by(|(k1, _), (k2, _)| k1.cmp(k2));
+        for (key, value) in key_value {
+            wstr.extend_from_slice(&key);
+            wstr.push(b'='.into());
+            let (disc, val_str) = match value {
+                LnvValue::WString(val) => ("0", val.to_string()),
+                LnvValue::I32(val) => ("1", val.to_string()),
+                LnvValue::F32(val) => ("3", val.to_string()),
+                LnvValue::F64(val) => ("4", val.to_string()),
+                LnvValue::U32(val) => ("5", val.to_string()),
+                LnvValue::Bool(val) => ("7", (*val as u8).to_string()),
+                LnvValue::I64(val) => ("8", val.to_string()),
+                LnvValue::U64(val) => ("9", val.to_string()),
+                LnvValue::String(val) => ("13", val.to_string()),
+            };
+            wstr.extend_from_slice(&LuVarWString::<u32>::try_from(disc).unwrap());
+            wstr.push(b':'.into());
+            wstr.extend_from_slice(&LuVarWString::<u32>::try_from(val_str.as_str()).unwrap());
+            i += 1;
+            if i < len {
+                wstr.push(b'\n'.into());
+            }
+        }
+        wstr
+    }
 }
 
 impl GmParam for LuNameValue {
-	fn deserialize<R: ::std::io::Read>(reader: &mut R) -> ::std::io::Result<Self> {
-		let lu_var_wstr: LuVarWString<u32> = LERead::read(reader)?;
-		if !lu_var_wstr.is_empty() {
-			let _: u16 = LERead::read(reader)?; // for some reason has a null terminator
-		}
-		Ok((&lu_var_wstr).into())
-	}
+    fn deserialize<R: ::std::io::Read>(reader: &mut R) -> ::std::io::Result<Self> {
+        let lu_var_wstr: LuVarWString<u32> = LERead::read(reader)?;
+        if !lu_var_wstr.is_empty() {
+            let _: u16 = LERead::read(reader)?; // for some reason has a null terminator
+        }
+        Ok((&lu_var_wstr).into())
+    }
 
-	fn serialize<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
-		let lu_var_wstr: LuVarWString<u32> = self.into();
-		LEWrite::write(writer, &lu_var_wstr)?;
-		if !lu_var_wstr.is_empty() {
-			LEWrite::write(writer, 0u16)?; // for some reason has a null terminator
-		}
-		Ok(())
-	}
+    fn serialize<W: ::std::io::Write>(&self, writer: &mut W) -> ::std::io::Result<()> {
+        let lu_var_wstr: LuVarWString<u32> = self.into();
+        LEWrite::write(writer, &lu_var_wstr)?;
+        if !lu_var_wstr.is_empty() {
+            LEWrite::write(writer, 0u16)?; // for some reason has a null terminator
+        }
+        Ok(())
+    }
 }

--- a/src/world/lnv.rs
+++ b/src/world/lnv.rs
@@ -29,7 +29,7 @@ pub enum LnvValue {
 impl LnvValue {
     fn parse_ty_val(wstr: &LuWStr) -> Self {
         let string: String = wstr.to_string();
-        let (ty, val) = string.split_at(string.find(":").unwrap());
+        let (ty, val) = string.split_at(string.find(':').unwrap());
         let val = val.split_at(1).1;
         match ty {
             "0" => LnvValue::WString(val.try_into().unwrap()),
@@ -129,12 +129,12 @@ impl<const N: usize> From<&[u8; N]> for LnvValue {
 }
 
 /// A hash map with values being one of multiple possible types.
-#[derive(PartialEq)]
+#[derive(PartialEq, Default)]
 pub struct LuNameValue(HashMap<LuVarWString<u32>, LnvValue>);
 
 impl LuNameValue {
     pub fn new() -> Self {
-        LuNameValue(HashMap::new())
+        Self::default()
     }
 }
 
@@ -260,7 +260,7 @@ impl From<&LuNameValue> for LuVarWString<u32> {
         let mut key_value: Vec<_> = lnv.0.iter().collect();
         key_value.sort_unstable_by(|(k1, _), (k2, _)| k1.cmp(k2));
         for (key, value) in key_value {
-            wstr.extend_from_slice(&key);
+            wstr.extend_from_slice(key);
             wstr.push(b'='.into());
             let (disc, val_str) = match value {
                 LnvValue::WString(val) => ("0", val.to_string()),

--- a/src/world/mod.rs
+++ b/src/world/mod.rs
@@ -1,15 +1,15 @@
 //! World messages.
+pub mod amf3;
 pub mod client;
 pub mod gm;
-pub mod amf3;
 mod lnv;
 pub mod server;
 
 use std::cmp::PartialEq;
 
 use endio::{Deserialize, Serialize};
-use lu_packets_derive::GmParam;
 pub use lnv::*;
+use lu_packets_derive::GmParam;
 
 pub type Lot = u32;
 const LOT_NULL: Lot = -1i32 as Lot;
@@ -23,34 +23,47 @@ const CLONE_ID_INVALID: CloneId = 0;
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, GmParam)]
 pub struct ZoneId {
-	pub map_id: MapId,
-	pub instance_id: u16,
-	pub clone_id: CloneId,
+    pub map_id: MapId,
+    pub instance_id: u16,
+    pub clone_id: CloneId,
 }
 
 impl ZoneId {
-	const INVALID: Self = Self { map_id: 0, instance_id: 0, clone_id: 0 };
+    const INVALID: Self = Self {
+        map_id: 0,
+        instance_id: 0,
+        clone_id: 0,
+    };
 }
 
 #[derive(Copy, Clone, Debug, Default, Deserialize, Serialize, PartialEq, GmParam)]
 pub struct Vector3 {
-	pub x: f32,
-	pub y: f32,
-	pub z: f32,
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
 }
 
 impl Vector3 {
-	pub const ZERO: Self = Self { x: 0.0, y: 0.0, z: 0.0 };
+    pub const ZERO: Self = Self {
+        x: 0.0,
+        y: 0.0,
+        z: 0.0,
+    };
 }
 
 #[derive(Copy, Clone, Debug, Default, Deserialize, Serialize, PartialEq, GmParam)]
 pub struct Quaternion {
-	pub x: f32,
-	pub y: f32,
-	pub z: f32,
-	pub w: f32,
+    pub x: f32,
+    pub y: f32,
+    pub z: f32,
+    pub w: f32,
 }
 
 impl Quaternion {
-	pub const IDENTITY: Self = Self { x: 0.0, y: 0.0, z: 0.0, w: 0.0 };
+    pub const IDENTITY: Self = Self {
+        x: 0.0,
+        y: 0.0,
+        z: 0.0,
+        w: 0.0,
+    };
 }

--- a/src/world/server/mail/mod.rs
+++ b/src/world/server/mail/mod.rs
@@ -6,42 +6,42 @@ use crate::common::{LuWString32, LuWString400, LuWString50, ObjId};
 #[derive(Debug, Deserialize, PartialEq, Serialize, VariantTests)]
 #[repr(u32)]
 pub enum Mail {
-	CreateRequest(CreateRequest) = 0,
-	ListRequest = 3,
-	ContentCollectRequest(ContentCollectRequest) = 5,
-	DeleteRequest(DeleteRequest) = 7,
-	MarkAsReadRequest(MarkAsReadRequest) = 9,
-	UnreadCountRequest = 11,
+    CreateRequest(CreateRequest) = 0,
+    ListRequest = 3,
+    ContentCollectRequest(ContentCollectRequest) = 5,
+    DeleteRequest(DeleteRequest) = 7,
+    MarkAsReadRequest(MarkAsReadRequest) = 9,
+    UnreadCountRequest = 11,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
-#[trailing_padding=4]
+#[trailing_padding = 4]
 pub struct CreateRequest {
-	pub subject: LuWString50,
-	pub body: LuWString400,
-	pub receiver_name: LuWString32,
-	#[padding=8] // money: i64, unused
-	pub attachment_id: ObjId,
-	pub attachment_count: u16,
-	pub locale_id: u16,
+    pub subject: LuWString50,
+    pub body: LuWString400,
+    pub receiver_name: LuWString32,
+    #[padding = 8] // money: i64, unused
+    pub attachment_id: ObjId,
+    pub attachment_count: u16,
+    pub locale_id: u16,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct ContentCollectRequest {
-	#[padding=4]
-	pub mail_id: ObjId,
-	pub receiver_id: ObjId,
+    #[padding = 4]
+    pub mail_id: ObjId,
+    pub receiver_id: ObjId,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct DeleteRequest {
-	#[padding=4]
-	pub mail_id: ObjId,
-	pub receiver_id: ObjId,
+    #[padding = 4]
+    pub mail_id: ObjId,
+    pub receiver_id: ObjId,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct MarkAsReadRequest {
-	#[padding=4]
-	pub mail_id: ObjId,
+    #[padding = 4]
+    pub mail_id: ObjId,
 }

--- a/src/world/server/mod.rs
+++ b/src/world/server/mod.rs
@@ -1,21 +1,21 @@
 //! Server-received world messages.
 pub mod mail;
 
-use std::io::{Read, Write};
 use std::io::Result as Res;
+use std::io::{Read, Write};
 
-use endio::{Deserialize, LERead, LEWrite, Serialize};
 use endio::LittleEndian as LE;
+use endio::{Deserialize, LERead, LEWrite, Serialize};
 use endio_bit::{BEBitReader, BEBitWriter};
 use lu_packets_derive::VariantTests;
 
-use crate::common::{ObjId, LuVarWString, LuWString33, LuWString42, ServiceId};
-use crate::chat::ChatChannel;
-use crate::chat::server::ChatMessage;
-use crate::raknet::client::replica::controllable_physics::FrameStats;
-use super::ZoneId;
-use super::gm::server::SubjectGameMessage;
 use self::mail::Mail;
+use super::gm::server::SubjectGameMessage;
+use super::ZoneId;
+use crate::chat::server::ChatMessage;
+use crate::chat::ChatChannel;
+use crate::common::{LuVarWString, LuWString33, LuWString42, ObjId, ServiceId};
+use crate::raknet::client::replica::controllable_physics::FrameStats;
 
 pub use crate::general::server::GeneralMessage;
 
@@ -26,302 +26,308 @@ pub type Message = crate::raknet::server::Message<LuMessage>;
 #[derive(Debug, Deserialize, PartialEq, Serialize, VariantTests)]
 #[repr(u16)]
 pub enum LuMessage {
-	General(GeneralMessage) = ServiceId::General as u16,
-	World(WorldMessage) = ServiceId::World as u16,
+    General(GeneralMessage) = ServiceId::General as u16,
+    World(WorldMessage) = ServiceId::World as u16,
 }
 
 /// All server-received world messages.
 #[derive(Debug, Deserialize, PartialEq, Serialize, VariantTests)]
-#[post_disc_padding=1]
+#[post_disc_padding = 1]
 #[repr(u32)]
 pub enum WorldMessage {
-	ClientValidation(ClientValidation) = 1,
-	CharacterListRequest = 2,
-	CharacterCreateRequest(CharacterCreateRequest) = 3,
-	CharacterLoginRequest(CharacterLoginRequest) = 4,
-	SubjectGameMessage(SubjectGameMessage) = 5,
-	CharacterDeleteRequest(CharacterDeleteRequest) = 6,
-	GeneralChatMessage(GeneralChatMessage) = 14,
-	LevelLoadComplete(LevelLoadComplete) = 19,
-	RouteMessage(RouteMessage) = 21,
-	PositionUpdate(PositionUpdate) = 22,
-	Mail(Mail) = 23,
-	StringCheck(StringCheck) = 25,
-	RequestFreeTrialRefresh = 32,
-	Top5IssuesRequest(Top5IssuesRequest) = 91,
-	UgcDownloadFailed(UgcDownloadFailed) = 120,
+    ClientValidation(ClientValidation) = 1,
+    CharacterListRequest = 2,
+    CharacterCreateRequest(CharacterCreateRequest) = 3,
+    CharacterLoginRequest(CharacterLoginRequest) = 4,
+    SubjectGameMessage(SubjectGameMessage) = 5,
+    CharacterDeleteRequest(CharacterDeleteRequest) = 6,
+    GeneralChatMessage(GeneralChatMessage) = 14,
+    LevelLoadComplete(LevelLoadComplete) = 19,
+    RouteMessage(RouteMessage) = 21,
+    PositionUpdate(PositionUpdate) = 22,
+    Mail(Mail) = 23,
+    StringCheck(StringCheck) = 25,
+    RequestFreeTrialRefresh = 32,
+    Top5IssuesRequest(Top5IssuesRequest) = 91,
+    UgcDownloadFailed(UgcDownloadFailed) = 120,
 }
 
 /**
-	Provides session info for authentication.
+    Provides session info for authentication.
 
-	### Trigger
-	Receipt of [Server handshake](crate::general::client::Handshake).
+    ### Trigger
+    Receipt of [Server handshake](crate::general::client::Handshake).
 
-	### Handling
-	Verify with your auth server that the `(username, session_key)` combination is valid. If not, immediately disconnect the client, ideally with a [`DisconnectNotify::InvalidSessionKey`](crate::general::client::DisconnectNotify::InvalidSessionKey).
+    ### Handling
+    Verify with your auth server that the `(username, session_key)` combination is valid. If not, immediately disconnect the client, ideally with a [`DisconnectNotify::InvalidSessionKey`](crate::general::client::DisconnectNotify::InvalidSessionKey).
 
-	If you are concerned about players modding their client DB, also check the [`fdb_checksum`](Self::fdb_checksum). Note that players can still change their client to send a fake checksum, but this requires exe modding, which most players are presumably not familiar with.
+    If you are concerned about players modding their client DB, also check the [`fdb_checksum`](Self::fdb_checksum). Note that players can still change their client to send a fake checksum, but this requires exe modding, which most players are presumably not familiar with.
 
-	If all validation checks pass, store the connection -> username association, as this is the only packet that references the username.
+    If all validation checks pass, store the connection -> username association, as this is the only packet that references the username.
 
-	### Response
-	The client does not require a fixed response to this packet. However, world servers (with the exception of a dedicated char server) will usually want to respond to this with [`LoadStaticZone`](super::client::LoadStaticZone).
+    ### Response
+    The client does not require a fixed response to this packet. However, world servers (with the exception of a dedicated char server) will usually want to respond to this with [`LoadStaticZone`](super::client::LoadStaticZone).
 
-	### Notes
-	**Important**: Do **not** handle any other packets from clients that have not yet been validated. Handling other packets before validation can lead to errors because the connection has not yet been associated with a username, and can lead to security vulnerabilities if session keys are not validated properly.
+    ### Notes
+    **Important**: Do **not** handle any other packets from clients that have not yet been validated. Handling other packets before validation can lead to errors because the connection has not yet been associated with a username, and can lead to security vulnerabilities if session keys are not validated properly.
 */
 #[derive(Debug, PartialEq)]
 pub struct ClientValidation {
-	/// Account username.
-	pub username: LuWString33,
-	/// [Session key from auth's login response](crate::auth::client::LoginResponse::Ok::session_key).
-	pub session_key: LuWString33,
-	/// MD5 hash of null-terminated cdclient.fdb file contents.
-	pub fdb_checksum: [u8; 32],
+    /// Account username.
+    pub username: LuWString33,
+    /// [Session key from auth's login response](crate::auth::client::LoginResponse::Ok::session_key).
+    pub session_key: LuWString33,
+    /// MD5 hash of null-terminated cdclient.fdb file contents.
+    pub fdb_checksum: [u8; 32],
 }
 
-impl<R: Read+LERead> Deserialize<LE, R> for ClientValidation
-	where   u8: Deserialize<LE, R>,
-	  LuWString33: Deserialize<LE, R> {
-	fn deserialize(reader: &mut R) -> Res<Self> {
-		let username         = LERead::read(reader)?;
-		let session_key      = LERead::read(reader)?;
-		let mut fdb_checksum = [0; 32];
-		std::io::Read::read(reader, &mut fdb_checksum)?;
-		// garbage byte because the devs messed up the null terminator
-		let _ : u8           =  LERead::read(reader)?;
-		Ok(Self {
-			username,
-			session_key,
-			fdb_checksum,
-		})
-	}
+impl<R: Read + LERead> Deserialize<LE, R> for ClientValidation
+where
+    u8: Deserialize<LE, R>,
+    LuWString33: Deserialize<LE, R>,
+{
+    fn deserialize(reader: &mut R) -> Res<Self> {
+        let username = LERead::read(reader)?;
+        let session_key = LERead::read(reader)?;
+        let mut fdb_checksum = [0; 32];
+        std::io::Read::read(reader, &mut fdb_checksum)?;
+        // garbage byte because the devs messed up the null terminator
+        let _: u8 = LERead::read(reader)?;
+        Ok(Self {
+            username,
+            session_key,
+            fdb_checksum,
+        })
+    }
 }
 
-impl<'a, W: Write+LEWrite> Serialize<LE, W> for &'a ClientValidation
-	where       u8: Serialize<LE, W>,
-	  &'a LuWString33: Serialize<LE, W> {
-	fn serialize(self, writer: &mut W) -> Res<()> {
-		LEWrite::write(writer, &self.username)?;
-		LEWrite::write(writer, &self.session_key)?;
-		Write::write(writer, &self.fdb_checksum)?;
-		// garbage byte because the devs messed up the null terminator
-		LEWrite::write(writer, 0u8)
-	}
+impl<'a, W: Write + LEWrite> Serialize<LE, W> for &'a ClientValidation
+where
+    u8: Serialize<LE, W>,
+    &'a LuWString33: Serialize<LE, W>,
+{
+    fn serialize(self, writer: &mut W) -> Res<()> {
+        LEWrite::write(writer, &self.username)?;
+        LEWrite::write(writer, &self.session_key)?;
+        Write::write(writer, &self.fdb_checksum)?;
+        // garbage byte because the devs messed up the null terminator
+        LEWrite::write(writer, 0u8)
+    }
 }
 
 /**
-	Requests a new character to be created.
+    Requests a new character to be created.
 
-	### Trigger
-	The player creating a new character and submitting it to the server.
+    ### Trigger
+    The player creating a new character and submitting it to the server.
 
-	### Handling
-	Check if the predefined name is available. If the custom name is set, check if it is available as well. If your server has a name policy, check if the custom name is known to be unacceptable.
+    ### Handling
+    Check if the predefined name is available. If the custom name is set, check if it is available as well. If your server has a name policy, check if the custom name is known to be unacceptable.
 
-	If all checks pass, create the character and save it to the database using the information specified in this message.
+    If all checks pass, create the character and save it to the database using the information specified in this message.
 
-	### Response
-	Respond with [`CharacterCreateResponse`](super::client::CharacterCreateResponse), using the appropriate variant to indicate the result. If the character creation is successful, additionally send a [`CharacterListResponse`](super::client::CharacterListResponse) afterwards with the new character included.
+    ### Response
+    Respond with [`CharacterCreateResponse`](super::client::CharacterCreateResponse), using the appropriate variant to indicate the result. If the character creation is successful, additionally send a [`CharacterListResponse`](super::client::CharacterListResponse) afterwards with the new character included.
 */
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
-#[trailing_padding=1]
+#[trailing_padding = 1]
 pub struct CharacterCreateRequest {
-	/// The custom name, or blank if the predefined name is to be used.
-	pub char_name: LuWString33,
-	/// First part of the predefined name.
-	pub predef_name_id_1: u32, // todo: enum
-	/// Second part of the predefined name.
-	pub predef_name_id_2: u32, // todo: enum
-	/// Third part of the predefined name.
-	pub predef_name_id_3: u32, // todo: enum
-	#[padding=9]
-	/// Chosen torso color.
-	pub torso_color: u32, // todo: enum
-	#[padding=4]
-	/// Chosen legs color.
-	pub legs_color: u32, // todo: enum
-	/// Chosen hair style.
-	pub hair_style: u32, // todo: enum
-	/// Chosen hair color.
-	pub hair_color: u32, // todo: enum
-	#[padding=8]
-	/// Chosen eyebrow style.
-	pub eyebrows_style: u32, // todo: enum
-	/// Chosen eye style.
-	pub eyes_style: u32, // todo: enum
-	/// Chosen mouth style.
-	pub mouth_style: u32, // todo: enum
+    /// The custom name, or blank if the predefined name is to be used.
+    pub char_name: LuWString33,
+    /// First part of the predefined name.
+    pub predef_name_id_1: u32, // todo: enum
+    /// Second part of the predefined name.
+    pub predef_name_id_2: u32, // todo: enum
+    /// Third part of the predefined name.
+    pub predef_name_id_3: u32, // todo: enum
+    #[padding = 9]
+    /// Chosen torso color.
+    pub torso_color: u32, // todo: enum
+    #[padding = 4]
+    /// Chosen legs color.
+    pub legs_color: u32, // todo: enum
+    /// Chosen hair style.
+    pub hair_style: u32, // todo: enum
+    /// Chosen hair color.
+    pub hair_color: u32, // todo: enum
+    #[padding = 8]
+    /// Chosen eyebrow style.
+    pub eyebrows_style: u32, // todo: enum
+    /// Chosen eye style.
+    pub eyes_style: u32, // todo: enum
+    /// Chosen mouth style.
+    pub mouth_style: u32, // todo: enum
 }
 
 /**
-	Indicates that the player has chosen a character to play with.
+    Indicates that the player has chosen a character to play with.
 
-	### Trigger
-	The player selecting the character in the character selection screen and pressing play.
+    ### Trigger
+    The player selecting the character in the character selection screen and pressing play.
 
-	### Handling
-	Do what's necessary to let the character join the world it was last in. In the common case of the world server instance being different from the current instance, redirect the client to the world instance.
+    ### Handling
+    Do what's necessary to let the character join the world it was last in. In the common case of the world server instance being different from the current instance, redirect the client to the world instance.
 
-	### Response
-	Respond with [`LoadStaticZone`](super::client::LoadStaticZone) if you're not switching instances, or [`TransferToWorld`](super::client::TransferToWorld) if you do.
+    ### Response
+    Respond with [`LoadStaticZone`](super::client::LoadStaticZone) if you're not switching instances, or [`TransferToWorld`](super::client::TransferToWorld) if you do.
 */
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct CharacterLoginRequest {
-	/// The object ID of the chosen character.
-	pub char_id: ObjId,
+    /// The object ID of the chosen character.
+    pub char_id: ObjId,
 }
 
 /**
-	Requests a character to be deleted.
+    Requests a character to be deleted.
 
-	### Trigger
-	The player deleting the character and confirming with their password.
+    ### Trigger
+    The player deleting the character and confirming with their password.
 
-	### Handling
-	Delete the character from the database, with appropriate cascading deletes, such as deleting the characters from any friends lists they're in.
+    ### Handling
+    Delete the character from the database, with appropriate cascading deletes, such as deleting the characters from any friends lists they're in.
 
-	### Response
-	Respond with [`CharacterDeleteResponse`](super::client::CharacterDeleteResponse) indicating whether deletion was successful.
+    ### Response
+    Respond with [`CharacterDeleteResponse`](super::client::CharacterDeleteResponse) indicating whether deletion was successful.
 */
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct CharacterDeleteRequest {
-	/// The object ID of the chosen character.
-	pub char_id: ObjId,
+    /// The object ID of the chosen character.
+    pub char_id: ObjId,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct GeneralChatMessage {
-	pub chat_channel: ChatChannel,
-	pub source_id: u16,
-	pub message: LuVarWString<u32>,
+    pub chat_channel: ChatChannel,
+    pub source_id: u16,
+    pub message: LuVarWString<u32>,
 }
 
-impl<R: Read+LERead> Deserialize<LE, R> for GeneralChatMessage
-	where   u8: Deserialize<LE, R>,
-	  LuWString33: Deserialize<LE, R> {
-	fn deserialize(reader: &mut R) -> Res<Self> {
-		let chat_channel = LERead::read(reader)?;
-		let source_id    = LERead::read(reader)?;
-		let mut str_len: u32 = LERead::read(reader)?;
-		str_len -= 1;
-		let message = LuVarWString::deser_content(reader, str_len)?;
-		let _: u16       = LERead::read(reader)?;
-		Ok(Self {
-			chat_channel,
-			source_id,
-			message,
-		})
-	}
+impl<R: Read + LERead> Deserialize<LE, R> for GeneralChatMessage
+where
+    u8: Deserialize<LE, R>,
+    LuWString33: Deserialize<LE, R>,
+{
+    fn deserialize(reader: &mut R) -> Res<Self> {
+        let chat_channel = LERead::read(reader)?;
+        let source_id = LERead::read(reader)?;
+        let mut str_len: u32 = LERead::read(reader)?;
+        str_len -= 1;
+        let message = LuVarWString::deser_content(reader, str_len)?;
+        let _: u16 = LERead::read(reader)?;
+        Ok(Self {
+            chat_channel,
+            source_id,
+            message,
+        })
+    }
 }
 
-impl<'a, W: Write+LEWrite> Serialize<LE, W> for &'a GeneralChatMessage {
-	fn serialize(self, writer: &mut W) -> Res<()> {
-		LEWrite::write(writer, &self.chat_channel)?;
-		LEWrite::write(writer, self.source_id)?;
-		let mut str_len = self.message.len();
-		str_len += 1;
-		LEWrite::write(writer, str_len as u32)?;
-		self.message.ser_content(writer)?;
-		LEWrite::write(writer, 0u16)
-	}
+impl<'a, W: Write + LEWrite> Serialize<LE, W> for &'a GeneralChatMessage {
+    fn serialize(self, writer: &mut W) -> Res<()> {
+        LEWrite::write(writer, &self.chat_channel)?;
+        LEWrite::write(writer, self.source_id)?;
+        let mut str_len = self.message.len();
+        str_len += 1;
+        LEWrite::write(writer, str_len as u32)?;
+        self.message.ser_content(writer)?;
+        LEWrite::write(writer, 0u16)
+    }
 }
 
 /**
-	Reports to the server that client-side loading has finished.
+    Reports to the server that client-side loading has finished.
 
-	### Trigger
-	The client finishing a zone load initiated by [`LoadStaticZone`](super::client::LoadStaticZone).
+    ### Trigger
+    The client finishing a zone load initiated by [`LoadStaticZone`](super::client::LoadStaticZone).
 
-	### Handling / Response
-	Respond with [`CreateCharacter`](super::client::CreateCharacter) containing details about the player's character. Add the client to your server's replica manager, so that existing objects in range are replicated using [`ReplicaConstruction`](crate::raknet::client::replica::ReplicaConstruction). Create the character's replica object and and let the replica manager broadcast its construction to all clients in range. Finally, send [`ServerDoneLoadingAllObjects`](crate::world::gm::client::GameMessage::ServerDoneLoadingAllObjects) from the character object to the client.
+    ### Handling / Response
+    Respond with [`CreateCharacter`](super::client::CreateCharacter) containing details about the player's character. Add the client to your server's replica manager, so that existing objects in range are replicated using [`ReplicaConstruction`](crate::raknet::client::replica::ReplicaConstruction). Create the character's replica object and and let the replica manager broadcast its construction to all clients in range. Finally, send [`ServerDoneLoadingAllObjects`](crate::world::gm::client::GameMessage::ServerDoneLoadingAllObjects) from the character object to the client.
 */
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct LevelLoadComplete {
-	/// The ID of the zone that was loaded. Servers should not trust this, as a player could use it to get into zones they don't belong.
-	pub zone_id: ZoneId,
+    /// The ID of the zone that was loaded. Servers should not trust this, as a player could use it to get into zones they don't belong.
+    pub zone_id: ZoneId,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
-#[pre_disc_padding=4]
+#[pre_disc_padding = 4]
 #[repr(u16)]
 pub enum RouteMessage {
-	Chat(ChatMessage) = ServiceId::Chat as u16,
+    Chat(ChatMessage) = ServiceId::Chat as u16,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct PositionUpdate {
-	pub frame_stats: FrameStats,
+    pub frame_stats: FrameStats,
 }
 
 impl<R: Read> Deserialize<LE, R> for PositionUpdate {
-	fn deserialize(reader: &mut R) -> Res<Self> {
-		let mut reader = BEBitReader::new(reader);
-		let frame_stats = LERead::read(&mut reader)?;
-		Ok(Self { frame_stats })
-	}
+    fn deserialize(reader: &mut R) -> Res<Self> {
+        let mut reader = BEBitReader::new(reader);
+        let frame_stats = LERead::read(&mut reader)?;
+        Ok(Self { frame_stats })
+    }
 }
 
 impl<'a, W: Write> Serialize<LE, W> for &'a PositionUpdate {
-	fn serialize(self, writer: &mut W) -> Res<()> {
-		let mut writer = BEBitWriter::new(writer);
-		LEWrite::write(&mut writer, &self.frame_stats)
-	}
+    fn serialize(self, writer: &mut W) -> Res<()> {
+        let mut writer = BEBitWriter::new(writer);
+        LEWrite::write(&mut writer, &self.frame_stats)
+    }
 }
 
 /**
-	Asks the server whether a string the player entered is acceptable.
+    Asks the server whether a string the player entered is acceptable.
 
-	### Trigger
-	The player entering a string in the chat box. This message is sent as the player is typing, before pressing enter.
+    ### Trigger
+    The player entering a string in the chat box. This message is sent as the player is typing, before pressing enter.
 
-	### Handling
-	Check whether the [`string`](Self::string) is acceptable per the server's moderation policy, taking into account the player's chat mode and best friend status with possible recipient.
+    ### Handling
+    Check whether the [`string`](Self::string) is acceptable per the server's moderation policy, taking into account the player's chat mode and best friend status with possible recipient.
 
-	### Response
-	Respond with [`ChatModerationString`](super::client::ChatModerationString), indicating whether the string is ok, or if not, the spans that are not acceptable.
+    ### Response
+    Respond with [`ChatModerationString`](super::client::ChatModerationString), indicating whether the string is ok, or if not, the spans that are not acceptable.
 
-	### Notes
-	This message is only for quick player feedback on acceptability. Final string submissions by the player will be sent in different messages (e.g. [`GeneralChatMessage`] or `Mail` (todo)). Those messages will need to be checked for moderation as well. This means that there's no harm in trusting the client to provide accurate context ([`chat_mode`](Self::chat_mode), [`recipient_name`](Self::recipient_name) in this message.
+    ### Notes
+    This message is only for quick player feedback on acceptability. Final string submissions by the player will be sent in different messages (e.g. [`GeneralChatMessage`] or `Mail` (todo)). Those messages will need to be checked for moderation as well. This means that there's no harm in trusting the client to provide accurate context ([`chat_mode`](Self::chat_mode), [`recipient_name`](Self::recipient_name) in this message.
 */
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct StringCheck {
-	pub chat_mode: u8, // todo: type?
-	pub request_id: u8,
-	pub recipient_name: LuWString42,
-	/// The string to be checked.
-	pub string: LuVarWString<u16>,
+    pub chat_mode: u8, // todo: type?
+    pub request_id: u8,
+    pub recipient_name: LuWString42,
+    /// The string to be checked.
+    pub string: LuVarWString<u16>,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[repr(u32)]
 #[allow(non_camel_case_types)]
 pub enum Language {
-	en_US,
-	pl_US,
-	de_DE,
-	en_GB,
+    en_US,
+    pl_US,
+    de_DE,
+    en_GB,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct Top5IssuesRequest {
-	pub language: Language,
+    pub language: Language,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[repr(u32)]
 pub enum UgcResType {
-	Lxfml,
-	Nif,
-	Hkx,
-	Dds,
+    Lxfml,
+    Nif,
+    Hkx,
+    Dds,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct UgcDownloadFailed {
-	pub res_type: UgcResType,
-	pub blueprint_id: ObjId,
-	pub status_code: u32,
-	pub char_id: ObjId,
+    pub res_type: UgcResType,
+    pub blueprint_id: ObjId,
+    pub status_code: u32,
+    pub char_id: ObjId,
 }


### PR DESCRIPTION
This PR runs `cargo fmt` and fixes all but one `cargo clippy` problem.

The issue with that last one ist that it is essentially a case for <https://github.com/rust-lang/rfcs/blob/master/text/2930-read-buf.md#summary>, where you can cause undefined behavior by assuming a `impl std::io::Read` initializes a byte slice but you have a noticable performance regression if you don't and zero-initialize it. That has two possible solutions:

1. Use the nightly `read_buf` APIs
2. Just zero-init it, because it's just in `impl GmParam for Vec<u8>`

which is why I left it out of this PR