### PR TITLE
Add lot 2248 to readable packets

### DIFF
--- a/examples/capture_parser/main.rs
+++ b/examples/capture_parser/main.rs
@@ -130,7 +130,6 @@ fn parse(path: &Path, cdclient: &mut Cdclient) -> Res<usize> {
 		&& !file.name().contains("[1647]")
 		&& !file.name().contains("[1648]"))
 		|| (file.name().contains("[24]")
-		&& !file.name().contains("(2248)")
 		&& !file.name().contains("(2365)")
 		&& !file.name().contains("(4734)")
 		&& !file.name().contains("(4930)")


### PR DESCRIPTION
From reading ~12 or so construction packets, they all unserialized just fine, however if there is an issue somewhere else (like unserializing a serialization), then I'll look into that.  However none of the 12 packets with explicitly 2248 in them failed to unserialize.