### PR TITLE
Unified packet enum

### DIFF
--- a/examples/capture_parser/main.rs
+++ b/examples/capture_parser/main.rs
@@ -180,11 +180,6 @@ fn parse(path: &Path, cdclient: &mut Cdclient) -> Res<usize> {
 			}
 			i += 1; continue
 		} else { i += 1; continue }
-		// assert fully read
-		let mut rest = vec![];
-		std::io::Read::read_to_end(&mut file, &mut rest).unwrap();
-		assert_eq!(rest, vec![], "Zip: {}, Filename: {}, {} bytes", path.to_str().unwrap(), file.name(), file.size());
-		i += 1;
 	}
 	Ok(packet_count)
 }

--- a/examples/capture_parser/main.rs
+++ b/examples/capture_parser/main.rs
@@ -8,13 +8,8 @@ use std::fs::File;
 use std::path::Path;
 use std::time::Instant;
 
-use lu_packets::{
-	auth::server::Message as AuthServerMessage,
-	auth::client::Message as AuthClientMessage,
-	world::Lot,
-	world::server::Message as WorldServerMessage,
-	world::client::Message as WorldClientMessage,
-};
+use lu_packets::world::Lot;
+use lu_packets::unified::Message;
 use rusqlite::{params, Connection};
 use zip::ZipArchive;
 use self::zip_context::ZipContext;
@@ -54,7 +49,6 @@ fn parse(path: &Path, cdclient: &mut Cdclient) -> Res<usize> {
 	use endio::LERead;
 
 	if path.extension().unwrap() != "zip" { return Ok(0); }
-
 	let src = BufReader::new(File::open(path).unwrap());
 	let mut zip = ZipArchive::new(src).unwrap();
 	let mut comps = HashMap::new();
@@ -65,29 +59,7 @@ fn parse(path: &Path, cdclient: &mut Cdclient) -> Res<usize> {
 		if file.name().contains("of") {
 			i += 1; continue;
 		}
-		if file.name().contains("[53-01-") {
-			let msg: AuthServerMessage = file.read().expect(&format!("Zip: {}, Filename: {}, {} bytes", path.to_str().unwrap(), file.name(), file.size()));
-			if unsafe { PRINT_PACKETS } {
-				dbg!(msg);
-			}
-			packet_count += 1
-		} else if file.name().contains("[53-05-00-00]") {
-			let mut ctx = ZipContext { zip: file, comps: &mut comps, cdclient, assert_fully_read: true };
-			let msg: AuthClientMessage = ctx.read().expect(&format!("Zip: {}, Filename: {}, {} bytes", path.to_str().unwrap(), ctx.zip.name(), ctx.zip.size()));
-			file = ctx.zip;
-			if unsafe { PRINT_PACKETS } {
-				dbg!(&msg);
-			}
-			packet_count += 1;
-
-			if ctx.assert_fully_read {
-				// assert fully read
-				let mut rest = vec![];
-				std::io::Read::read_to_end(&mut file, &mut rest).unwrap();
-				assert_eq!(rest, vec![], "Zip: {}, Filename: {}, {} bytes", path.to_str().unwrap(), file.name(), file.size());
-			}
-			i += 1; continue
-		} else if file.name().contains("[53-04-")
+		if (file.name().contains("[53-01-")) || (file.name().contains("[53-05-00-00]")) || (file.name().contains("[53-04-")
 			&& !file.name().contains("[53-04-00-16]")
 			&& !file.name().contains("[e6-00]")
 			&& !file.name().contains("[6b-03]")
@@ -100,106 +72,100 @@ fn parse(path: &Path, cdclient: &mut Cdclient) -> Res<usize> {
 			&& !file.name().contains("[1046]")
 			&& !file.name().contains("[1097]")
 			&& !file.name().contains("[1197]")
-			&& !file.name().contains("[1308]")
-		{
-			let msg: WorldServerMessage = file.read().expect(&format!("Zip: {}, Filename: {}, {} bytes", path.to_str().unwrap(), file.name(), file.size()));
-			if unsafe { PRINT_PACKETS } {
-				dbg!(&msg);
-			}
-			packet_count += 1;
-		} else if file.name().contains("[53-02-") || (file.name().contains("[53-05-")
-		&& !file.name().contains("[53-05-00-00]")
-		&& !file.name().contains("[53-05-00-31]")
-		&& !file.name().contains("[e6-00]")
-		&& !file.name().contains("[ff-00]")
-		&& !file.name().contains("[a1-01]")
-		&& !file.name().contains("[7f-02]")
-		&& !file.name().contains("[a3-02]")
-		&& !file.name().contains("[cc-02]")
-		&& !file.name().contains("[35-03]")
-		&& !file.name().contains("[36-03]")
-		&& !file.name().contains("[4d-03]")
-		&& !file.name().contains("[6d-03]")
-		&& !file.name().contains("[91-03]")
-		&& !file.name().contains("[1a-05]")
-		&& !file.name().contains("[e6-05]")
-		&& !file.name().contains("[16-06]")
-		&& !file.name().contains("[1c-06]")
-		&& !file.name().contains("[6f-06]")
-		&& !file.name().contains("[70-06]")
-		&& !file.name().contains("[118]")
-		&& !file.name().contains("[230]")
-		&& !file.name().contains("[255]")
-		&& !file.name().contains("[417]")
-		&& !file.name().contains("[639]")
-		&& !file.name().contains("[675]")
-		&& !file.name().contains("[716]")
-		&& !file.name().contains("[821]")
-		&& !file.name().contains("[822]")
-		&& !file.name().contains("[845]")
-		&& !file.name().contains("[877]")
-		&& !file.name().contains("[913]")
-		&& !file.name().contains("[1306]")
-		&& !file.name().contains("[1510]")
-		&& !file.name().contains("[1558]")
-		&& !file.name().contains("[1564]")
-		&& !file.name().contains("[1647]")
-		&& !file.name().contains("[1648]"))
-		|| (file.name().contains("[24]")
-		&& !file.name().contains("(2365)")
-		&& !file.name().contains("(4734)")
-		&& !file.name().contains("(4930)")
-		&& !file.name().contains("(4955)")
-		&& !file.name().contains("(4967)")
-		&& !file.name().contains("(4990)")
-		&& !file.name().contains("(5635)")
-		&& !file.name().contains("(5651)")
-		&& !file.name().contains("(5652)")
-		&& !file.name().contains("(5903)")
-		&& !file.name().contains("(5904)")
-		&& !file.name().contains("(5958)")
-		&& !file.name().contains("(6007)")
-		&& !file.name().contains("(6010)")
-		&& !file.name().contains("(6097)")
-		&& !file.name().contains("(6209)")
-		&& !file.name().contains("(6267)")
-		&& !file.name().contains("(6289)")
-		&& !file.name().contains("(6290)")
-		&& !file.name().contains("(6319)")
-		&& !file.name().contains("(7001)")
-		&& !file.name().contains("(7100)")
-		&& !file.name().contains("(7282)")
-		&& !file.name().contains("(7796)")
-		&& !file.name().contains("(8304)")
-		&& !file.name().contains("(8575)")
-		&& !file.name().contains("(9741)")
-		&& !file.name().contains("(10039)")
-		&& !file.name().contains("(10042)")
-		&& !file.name().contains("(10046)")
-		&& !file.name().contains("(10055)")
-		&& !file.name().contains("(10097)")
-		&& !file.name().contains("(12916)")
-		&& !file.name().contains("(13773)")
-		&& !file.name().contains("(14376)")
-		&& !file.name().contains("(14447)")
-		&& !file.name().contains("(14449)")
-		&& !file.name().contains("(14476)")
-		&& !file.name().contains("(14477)")
-		&& !file.name().contains("(14505)")
-		&& !file.name().contains("(14510)")
-		&& !file.name().contains("(14539)")
-		&& !file.name().contains("(14540)")
-		&& !file.name().contains("(14541)")
-		&& !file.name().contains("(14542)")
-		&& !file.name().contains("(14543)")
-		&& !file.name().contains("(14544)")
-		&& !file.name().contains("(14545)")
-		&& !file.name().contains("(14546)")
-		&& !file.name().contains("(14547)"))
-		|| file.name().contains("[27]")
+			&& !file.name().contains("[1308]")) 
+			|| (file.name().contains("[53-02-") || (file.name().contains("[53-05-")
+			&& !file.name().contains("[53-05-00-00]")
+			&& !file.name().contains("[53-05-00-31]")
+			&& !file.name().contains("[e6-00]")
+			&& !file.name().contains("[ff-00]")
+			&& !file.name().contains("[a1-01]")
+			&& !file.name().contains("[7f-02]")
+			&& !file.name().contains("[a3-02]")
+			&& !file.name().contains("[cc-02]")
+			&& !file.name().contains("[35-03]")
+			&& !file.name().contains("[36-03]")
+			&& !file.name().contains("[4d-03]")
+			&& !file.name().contains("[6d-03]")
+			&& !file.name().contains("[91-03]")
+			&& !file.name().contains("[1a-05]")
+			&& !file.name().contains("[e6-05]")
+			&& !file.name().contains("[16-06]")
+			&& !file.name().contains("[1c-06]")
+			&& !file.name().contains("[6f-06]")
+			&& !file.name().contains("[70-06]")
+			&& !file.name().contains("[118]")
+			&& !file.name().contains("[230]")
+			&& !file.name().contains("[255]")
+			&& !file.name().contains("[417]")
+			&& !file.name().contains("[639]")
+			&& !file.name().contains("[675]")
+			&& !file.name().contains("[716]")
+			&& !file.name().contains("[821]")
+			&& !file.name().contains("[822]")
+			&& !file.name().contains("[845]")
+			&& !file.name().contains("[877]")
+			&& !file.name().contains("[913]")
+			&& !file.name().contains("[1306]")
+			&& !file.name().contains("[1510]")
+			&& !file.name().contains("[1558]")
+			&& !file.name().contains("[1564]")
+			&& !file.name().contains("[1647]")
+			&& !file.name().contains("[1648]"))
+			|| (file.name().contains("[24]")
+			&& !file.name().contains("(2365)")
+			&& !file.name().contains("(4734)")
+			&& !file.name().contains("(4930)")
+			&& !file.name().contains("(4955)")
+			&& !file.name().contains("(4967)")
+			&& !file.name().contains("(4990)")
+			&& !file.name().contains("(5635)")
+			&& !file.name().contains("(5651)")
+			&& !file.name().contains("(5652)")
+			&& !file.name().contains("(5903)")
+			&& !file.name().contains("(5904)")
+			&& !file.name().contains("(5958)")
+			&& !file.name().contains("(6007)")
+			&& !file.name().contains("(6010)")
+			&& !file.name().contains("(6097)")
+			&& !file.name().contains("(6209)")
+			&& !file.name().contains("(6267)")
+			&& !file.name().contains("(6289)")
+			&& !file.name().contains("(6290)")
+			&& !file.name().contains("(6319)")
+			&& !file.name().contains("(7001)")
+			&& !file.name().contains("(7100)")
+			&& !file.name().contains("(7282)")
+			&& !file.name().contains("(7796)")
+			&& !file.name().contains("(8304)")
+			&& !file.name().contains("(8575)")
+			&& !file.name().contains("(9741)")
+			&& !file.name().contains("(10039)")
+			&& !file.name().contains("(10042)")
+			&& !file.name().contains("(10046)")
+			&& !file.name().contains("(10055)")
+			&& !file.name().contains("(10097)")
+			&& !file.name().contains("(12916)")
+			&& !file.name().contains("(13773)")
+			&& !file.name().contains("(14376)")
+			&& !file.name().contains("(14447)")
+			&& !file.name().contains("(14449)")
+			&& !file.name().contains("(14476)")
+			&& !file.name().contains("(14477)")
+			&& !file.name().contains("(14505)")
+			&& !file.name().contains("(14510)")
+			&& !file.name().contains("(14539)")
+			&& !file.name().contains("(14540)")
+			&& !file.name().contains("(14541)")
+			&& !file.name().contains("(14542)")
+			&& !file.name().contains("(14543)")
+			&& !file.name().contains("(14544)")
+			&& !file.name().contains("(14545)")
+			&& !file.name().contains("(14546)")
+			&& !file.name().contains("(14547)"))
+			|| file.name().contains("[27]"))
 		{
 			let mut ctx = ZipContext { zip: file, comps: &mut comps, cdclient, assert_fully_read: true };
-			let msg: WorldClientMessage = ctx.read().expect(&format!("Zip: {}, Filename: {}, {} bytes", path.to_str().unwrap(), ctx.zip.name(), ctx.zip.size()));
+			let msg: Message = ctx.read().expect(&format!("Zip: {}, Filename: {}, {} bytes", path.to_str().unwrap(), ctx.zip.name(), ctx.zip.size()));
 			file = ctx.zip;
 			if unsafe { PRINT_PACKETS } {
 				dbg!(&msg);

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -139,3 +139,4 @@ pub mod chat;
 pub mod common;
 pub mod general;
 pub mod world;
+pub mod unified;

--- a/src/unified/mod.rs
+++ b/src/unified/mod.rs
@@ -2,24 +2,24 @@ use crate::auth::client::LoginResponse;
 use crate::auth::server::AuthMessage;
 use crate::chat::client::AchievementNotify;
 use crate::chat::server::{
-    AddFriendRequest as ChatAddFriendRequest, AddFriendResponse as ChatAddFriendResponse,
-    AddIgnore, RequestMinimumChatMode, RequestMinimumChatModePrivate, TeamInvite as ChatTeamInvite,
-    TeamInviteResponse, TeamLeave,
+	AddFriendRequest as ChatAddFriendRequest, AddFriendResponse as ChatAddFriendResponse,
+	AddIgnore, RequestMinimumChatMode, RequestMinimumChatModePrivate, TeamInvite as ChatTeamInvite,
+	TeamInviteResponse, TeamLeave,
 };
 use crate::chat::{GeneralChatMessage, PrivateChatMessage};
 use crate::common::ServiceId;
 use crate::general::client::GeneralMessage;
 use crate::raknet::client::{
-    replica::{ReplicaConstruction, ReplicaSerialization},
-    ConnectedPong, ConnectionRequestAccepted,
+	replica::{ReplicaConstruction, ReplicaSerialization},
+	ConnectedPong, ConnectionRequestAccepted,
 };
 use crate::raknet::server::{ConnectionRequest, InternalPing, NewIncomingConnection};
 use crate::world::client::{
-    AddFriendRequest, AddFriendResponse, BlueprintLoadItemResponse, BlueprintSaveResponse,
-    CharacterCreateResponse, CharacterDeleteResponse, CharacterListResponse, ChatModerationString,
-    CreateCharacter, FriendUpdateNotify, GetFriendsListResponse, GetIgnoreListResponse,
-    LoadStaticZone, MinimumChatModeResponse, MinimumChatModeResponsePrivate, TeamInvite,
-    TransferToWorld, UpdateFreeTrialStatus,
+	AddFriendRequest, AddFriendResponse, BlueprintLoadItemResponse, BlueprintSaveResponse,
+	CharacterCreateResponse, CharacterDeleteResponse, CharacterListResponse, ChatModerationString,
+	CreateCharacter, FriendUpdateNotify, GetFriendsListResponse, GetIgnoreListResponse,
+	LoadStaticZone, MinimumChatModeResponse, MinimumChatModeResponsePrivate, TeamInvite,
+	TransferToWorld, UpdateFreeTrialStatus,
 };
 use crate::world::gm::client::SubjectGameMessage;
 use crate::world::server::WorldMessage;
@@ -30,25 +30,25 @@ use lu_packets_derive::MessageFromVariants;
 #[non_exhaustive]
 #[repr(u8)]
 pub enum Message {
-    InternalPing(InternalPing) = 0,
-    ConnectedPong(ConnectedPong) = 3,
-    ConnectionRequest(ConnectionRequest) = 4,
-    ConnectionRequestAccepted(ConnectionRequestAccepted) = 14,
-    NewIncomingConnection(NewIncomingConnection) = 17,
-    DisconnectionNotification = 19,
-    ReplicaConstruction(ReplicaConstruction) = 36,
-    ReplicaSerialization(ReplicaSerialization) = 39,
-    UserMessage(UserMessage) = 83,
+	InternalPing(InternalPing) = 0,
+	ConnectedPong(ConnectedPong) = 3,
+	ConnectionRequest(ConnectionRequest) = 4,
+	ConnectionRequestAccepted(ConnectionRequestAccepted) = 14,
+	NewIncomingConnection(NewIncomingConnection) = 17,
+	DisconnectionNotification = 19,
+	ReplicaConstruction(ReplicaConstruction) = 36,
+	ReplicaSerialization(ReplicaSerialization) = 39,
+	UserMessage(UserMessage) = 83,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, MessageFromVariants)]
 #[repr(u16)]
 pub enum UserMessage {
-    General(GeneralMessage) = ServiceId::General as u16,
-    Client(AnyClientMessage) = ServiceId::Client as u16,
-    Chat(AnyChatMessage) = ServiceId::Chat as u16,
-    World(WorldMessage) = ServiceId::World as u16,
-    Auth(AuthMessage) = ServiceId::Auth as u16,
+	General(GeneralMessage) = ServiceId::General as u16,
+	Client(AnyClientMessage) = ServiceId::Client as u16,
+	Chat(AnyChatMessage) = ServiceId::Chat as u16,
+	World(WorldMessage) = ServiceId::World as u16,
+	Auth(AuthMessage) = ServiceId::Auth as u16,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, MessageFromVariants)]
@@ -56,26 +56,26 @@ pub enum UserMessage {
 #[post_disc_padding = 1]
 #[repr(u32)]
 pub enum AnyClientMessage {
-    LoginResponse(LoginResponse) = 0,
-    LoadStaticZone(LoadStaticZone) = 2,
-    CreateCharacter(CreateCharacter) = 4,
-    CharacterListResponse(CharacterListResponse) = 6,
-    CharacterCreateResponse(CharacterCreateResponse) = 7,
-    CharacterDeleteResponse(CharacterDeleteResponse) = 11,
-    SubjectGameMessage(SubjectGameMessage) = 12,
-    TransferToWorld(TransferToWorld) = 14,
-    BlueprintSaveResponse(BlueprintSaveResponse) = 21,
-    BlueprintLoadItemResponse(BlueprintLoadItemResponse) = 23,
-    AddFriendRequest(AddFriendRequest) = 27,
-    AddFriendResponse(AddFriendResponse) = 28,
-    GetFriendsListResponse(GetFriendsListResponse) = 30,
-    FriendUpdateNotify(FriendUpdateNotify) = 31,
-    GetIgnoreListResponse(GetIgnoreListResponse) = 34,
-    TeamInvite(TeamInvite) = 35,
-    MinimumChatModeResponse(MinimumChatModeResponse) = 57,
-    MinimumChatModeResponsePrivate(MinimumChatModeResponsePrivate) = 58,
-    ChatModerationString(ChatModerationString) = 59,
-    UpdateFreeTrialStatus(UpdateFreeTrialStatus) = 62,
+	LoginResponse(LoginResponse) = 0,
+	LoadStaticZone(LoadStaticZone) = 2,
+	CreateCharacter(CreateCharacter) = 4,
+	CharacterListResponse(CharacterListResponse) = 6,
+	CharacterCreateResponse(CharacterCreateResponse) = 7,
+	CharacterDeleteResponse(CharacterDeleteResponse) = 11,
+	SubjectGameMessage(SubjectGameMessage) = 12,
+	TransferToWorld(TransferToWorld) = 14,
+	BlueprintSaveResponse(BlueprintSaveResponse) = 21,
+	BlueprintLoadItemResponse(BlueprintLoadItemResponse) = 23,
+	AddFriendRequest(AddFriendRequest) = 27,
+	AddFriendResponse(AddFriendResponse) = 28,
+	GetFriendsListResponse(GetFriendsListResponse) = 30,
+	FriendUpdateNotify(FriendUpdateNotify) = 31,
+	GetIgnoreListResponse(GetIgnoreListResponse) = 34,
+	TeamInvite(TeamInvite) = 35,
+	MinimumChatModeResponse(MinimumChatModeResponse) = 57,
+	MinimumChatModeResponsePrivate(MinimumChatModeResponsePrivate) = 58,
+	ChatModerationString(ChatModerationString) = 59,
+	UpdateFreeTrialStatus(UpdateFreeTrialStatus) = 62,
 }
 
 #[derive(Debug, Deserialize, Serialize, PartialEq, MessageFromVariants)]
@@ -83,18 +83,18 @@ pub enum AnyClientMessage {
 #[post_disc_padding = 9]
 #[repr(u32)]
 pub enum AnyChatMessage {
-    GeneralChatMessage(GeneralChatMessage) = 1,
-    PrivateChatMessage(PrivateChatMessage) = 2,
-    AddFriendRequest(ChatAddFriendRequest) = 7,
-    AddFriendResponse(ChatAddFriendResponse) = 8,
-    GetFriendsList = 10,
-    AddIgnore(AddIgnore) = 11,
-    GetIgnoreList = 13,
-    TeamInvite(ChatTeamInvite) = 15,
-    TeamInviteResponse(TeamInviteResponse) = 16,
-    TeamLeave(TeamLeave) = 18,
-    TeamGetStatus = 21,
-    RequestMinimumChatMode(RequestMinimumChatMode) = 50,
-    RequestMinimumChatModePrivate(RequestMinimumChatModePrivate) = 51,
-    AchievementNotify(AchievementNotify) = 59,
+	GeneralChatMessage(GeneralChatMessage) = 1,
+	PrivateChatMessage(PrivateChatMessage) = 2,
+	AddFriendRequest(ChatAddFriendRequest) = 7,
+	AddFriendResponse(ChatAddFriendResponse) = 8,
+	GetFriendsList = 10,
+	AddIgnore(AddIgnore) = 11,
+	GetIgnoreList = 13,
+	TeamInvite(ChatTeamInvite) = 15,
+	TeamInviteResponse(TeamInviteResponse) = 16,
+	TeamLeave(TeamLeave) = 18,
+	TeamGetStatus = 21,
+	RequestMinimumChatMode(RequestMinimumChatMode) = 50,
+	RequestMinimumChatModePrivate(RequestMinimumChatModePrivate) = 51,
+	AchievementNotify(AchievementNotify) = 59,
 }

--- a/src/unified/mod.rs
+++ b/src/unified/mod.rs
@@ -1,0 +1,127 @@
+use crate::auth::client::LoginResponse;
+use crate::auth::server::AuthMessage;
+use crate::chat::client::AchievementNotify;
+use crate::chat::server::{
+    AddFriendRequest as ChatAddFriendRequest, AddFriendResponse as ChatAddFriendResponse,
+    AddIgnore, RequestMinimumChatMode, RequestMinimumChatModePrivate, TeamInvite as ChatTeamInvite,
+    TeamInviteResponse, TeamLeave,
+};
+use crate::chat::{GeneralChatMessage, PrivateChatMessage};
+use crate::common::ServiceId;
+use crate::general::client::{DisconnectNotify, Handshake};
+use crate::general::client::GeneralMessage;
+use crate::raknet::client::{
+    replica::{ReplicaConstruction, ReplicaSerialization},
+    ConnectedPong, ConnectionRequestAccepted,
+};
+use crate::raknet::server::{ConnectionRequest, InternalPing, NewIncomingConnection};
+use crate::world::client::{
+    AddFriendRequest, AddFriendResponse, BlueprintLoadItemResponse, BlueprintSaveResponse,
+    CharacterCreateResponse, CharacterDeleteResponse, CharacterListResponse, ChatModerationString,
+    CreateCharacter, FriendUpdateNotify, GetFriendsListResponse, GetIgnoreListResponse,
+    LoadStaticZone, MinimumChatModeResponse, MinimumChatModeResponsePrivate, TeamInvite,
+    TransferToWorld, UpdateFreeTrialStatus,
+};
+use crate::world::gm::client::SubjectGameMessage;
+use crate::world::server::WorldMessage;
+use endio::{Deserialize, Serialize};
+use lu_packets_derive::MessageFromVariants;
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[non_exhaustive]
+#[repr(u8)]
+pub enum Message {
+    InternalPing(InternalPing) = 0,
+    ConnectedPong(ConnectedPong) = 3,
+    ConnectionRequest(ConnectionRequest) = 4,
+    ConnectionRequestAccepted(ConnectionRequestAccepted) = 14,
+    NewIncomingConnection(NewIncomingConnection) = 17,
+    DisconnectionNotification = 19,
+    ReplicaConstruction(ReplicaConstruction) = 36,
+    ReplicaSerialization(ReplicaSerialization) = 39,
+    UserMessage(UserMessage) = 83,
+}
+
+#[derive(Debug, MessageFromVariants, PartialEq, Serialize, Deserialize)]
+#[repr(u16)]
+pub enum UserMessage {
+    General(GeneralMessage) = ServiceId::General as u16,
+    Client(AnyClientMessage) = ServiceId::Client as u16,
+    Chat(AnyChatMessage) = ServiceId::Chat as u16,
+    World(WorldMessage) = ServiceId::World as u16,
+    Auth(AuthMessage) = ServiceId::Auth as u16,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[post_disc_padding = 1]
+#[repr(u32)]
+pub enum AnyGeneralMessage {
+    Handshake(Handshake),
+    DisconnectNotify(DisconnectNotify),
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize, MessageFromVariants)]
+#[non_exhaustive]
+#[post_disc_padding = 1]
+#[repr(u32)]
+pub enum AnyClientMessage {
+    LoginResponse(LoginResponse) = 0,
+    LoadStaticZone(LoadStaticZone) = 2,
+    CreateCharacter(CreateCharacter) = 4,
+    CharacterListResponse(CharacterListResponse) = 6,
+    CharacterCreateResponse(CharacterCreateResponse) = 7,
+    CharacterDeleteResponse(CharacterDeleteResponse) = 11,
+    SubjectGameMessage(SubjectGameMessage) = 12,
+    TransferToWorld(TransferToWorld) = 14,
+    BlueprintSaveResponse(BlueprintSaveResponse) = 21,
+    BlueprintLoadItemResponse(BlueprintLoadItemResponse) = 23,
+    AddFriendRequest(AddFriendRequest) = 27,
+    AddFriendResponse(AddFriendResponse) = 28,
+    GetFriendsListResponse(GetFriendsListResponse) = 30,
+    FriendUpdateNotify(FriendUpdateNotify) = 31,
+    GetIgnoreListResponse(GetIgnoreListResponse) = 34,
+    TeamInvite(TeamInvite) = 35,
+    MinimumChatModeResponse(MinimumChatModeResponse) = 57,
+    MinimumChatModeResponsePrivate(MinimumChatModeResponsePrivate) = 58,
+    ChatModerationString(ChatModerationString) = 59,
+    UpdateFreeTrialStatus(UpdateFreeTrialStatus) = 62,
+}
+
+#[derive(Debug, Deserialize, PartialEq, Serialize, MessageFromVariants)]
+#[non_exhaustive]
+#[post_disc_padding = 9]
+#[repr(u32)]
+pub enum AnyChatMessage {
+    GeneralChatMessage(GeneralChatMessage) = 1,
+    PrivateChatMessage(PrivateChatMessage) = 2,
+    AddFriendRequest(ChatAddFriendRequest) = 7,
+    AddFriendResponse(ChatAddFriendResponse) = 8,
+    GetFriendsList = 10,
+    AddIgnore(AddIgnore) = 11,
+    GetIgnoreList = 13,
+    TeamInvite(ChatTeamInvite) = 15,
+    TeamInviteResponse(TeamInviteResponse) = 16,
+    TeamLeave(TeamLeave) = 18,
+    TeamGetStatus = 21,
+    RequestMinimumChatMode(RequestMinimumChatMode) = 50,
+    RequestMinimumChatModePrivate(RequestMinimumChatModePrivate) = 51,
+    AchievementNotify(AchievementNotify) = 59,
+}
+
+impl From<UserMessage> for Message {
+    fn from(msg: UserMessage) -> Self {
+        Message::UserMessage(msg)
+    }
+}
+
+impl From<Handshake> for Message {
+    fn from(msg: Handshake) -> Self {
+        GeneralMessage::Handshake(msg).into()
+    }
+}
+
+impl From<DisconnectNotify> for Message {
+    fn from(msg: DisconnectNotify) -> Self {
+        GeneralMessage::DisconnectNotify(msg).into()
+    }
+}

--- a/src/unified/mod.rs
+++ b/src/unified/mod.rs
@@ -8,7 +8,6 @@ use crate::chat::server::{
 };
 use crate::chat::{GeneralChatMessage, PrivateChatMessage};
 use crate::common::ServiceId;
-use crate::general::client::{DisconnectNotify, Handshake};
 use crate::general::client::GeneralMessage;
 use crate::raknet::client::{
     replica::{ReplicaConstruction, ReplicaSerialization},
@@ -27,7 +26,7 @@ use crate::world::server::WorldMessage;
 use endio::{Deserialize, Serialize};
 use lu_packets_derive::MessageFromVariants;
 
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, MessageFromVariants)]
 #[non_exhaustive]
 #[repr(u8)]
 pub enum Message {
@@ -42,7 +41,7 @@ pub enum Message {
     UserMessage(UserMessage) = 83,
 }
 
-#[derive(Debug, MessageFromVariants, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, MessageFromVariants)]
 #[repr(u16)]
 pub enum UserMessage {
     General(GeneralMessage) = ServiceId::General as u16,
@@ -52,15 +51,7 @@ pub enum UserMessage {
     Auth(AuthMessage) = ServiceId::Auth as u16,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Serialize)]
-#[post_disc_padding = 1]
-#[repr(u32)]
-pub enum AnyGeneralMessage {
-    Handshake(Handshake),
-    DisconnectNotify(DisconnectNotify),
-}
-
-#[derive(Debug, Deserialize, PartialEq, Serialize, MessageFromVariants)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, MessageFromVariants)]
 #[non_exhaustive]
 #[post_disc_padding = 1]
 #[repr(u32)]
@@ -87,7 +78,7 @@ pub enum AnyClientMessage {
     UpdateFreeTrialStatus(UpdateFreeTrialStatus) = 62,
 }
 
-#[derive(Debug, Deserialize, PartialEq, Serialize, MessageFromVariants)]
+#[derive(Debug, Deserialize, Serialize, PartialEq, MessageFromVariants)]
 #[non_exhaustive]
 #[post_disc_padding = 9]
 #[repr(u32)]
@@ -106,22 +97,4 @@ pub enum AnyChatMessage {
     RequestMinimumChatMode(RequestMinimumChatMode) = 50,
     RequestMinimumChatModePrivate(RequestMinimumChatModePrivate) = 51,
     AchievementNotify(AchievementNotify) = 59,
-}
-
-impl From<UserMessage> for Message {
-    fn from(msg: UserMessage) -> Self {
-        Message::UserMessage(msg)
-    }
-}
-
-impl From<Handshake> for Message {
-    fn from(msg: Handshake) -> Self {
-        GeneralMessage::Handshake(msg).into()
-    }
-}
-
-impl From<DisconnectNotify> for Message {
-    fn from(msg: DisconnectNotify) -> Self {
-        GeneralMessage::DisconnectNotify(msg).into()
-    }
 }


### PR DESCRIPTION
This PR adds `lu_packets::unified::Message` which enables deserialization of packets without first knowing whether they're client-sent or server-sent and whether they're auth or world packets (see the [updated capture_parser code](https://github.com/lcdr/lu_packets/commit/0096ae65e44744af52a182a866c92b5d389155ad) for an example).