### PR TITLE
Configure & run rustfmt

### DIFF
--- a/examples/capture_parser/main.rs
+++ b/examples/capture_parser/main.rs
@@ -8,13 +8,7 @@ use std::fs::File;
 use std::path::Path;
 use std::time::Instant;
 
-use lu_packets::{
-	auth::server::Message as AuthServerMessage,
-	auth::client::Message as AuthClientMessage,
-	world::Lot,
-	world::server::Message as WorldServerMessage,
-	world::client::Message as WorldClientMessage,
-};
+use lu_packets::{auth::server::Message as AuthServerMessage, auth::client::Message as AuthClientMessage, world::Lot, world::server::Message as WorldServerMessage, world::client::Message as WorldClientMessage};
 use rusqlite::{params, Connection};
 use zip::ZipArchive;
 use self::zip_context::ZipContext;
@@ -43,8 +37,8 @@ fn visit_dirs(dir: &Path, cdclient: &mut Cdclient, level: usize) -> Res<usize> {
 		for entry in fs::read_dir(dir)? {
 			let entry = entry?;
 			let path = entry.path();
-			packet_count += if path.is_dir() { visit_dirs(&path, cdclient, level+1) } else { parse(&path, cdclient) }?;
-			println!("packet count = {:>level$}", packet_count, level=level*6);
+			packet_count += if path.is_dir() { visit_dirs(&path, cdclient, level + 1) } else { parse(&path, cdclient) }?;
+			println!("packet count = {:>level$}", packet_count, level = level * 6);
 		}
 	}
 	Ok(packet_count)
@@ -53,7 +47,9 @@ fn visit_dirs(dir: &Path, cdclient: &mut Cdclient, level: usize) -> Res<usize> {
 fn parse(path: &Path, cdclient: &mut Cdclient) -> Res<usize> {
 	use endio::LERead;
 
-	if path.extension().unwrap() != "zip" { return Ok(0); }
+	if path.extension().unwrap() != "zip" {
+		return Ok(0);
+	}
 
 	let src = BufReader::new(File::open(path).unwrap());
 	let mut zip = ZipArchive::new(src).unwrap();
@@ -63,7 +59,8 @@ fn parse(path: &Path, cdclient: &mut Cdclient) -> Res<usize> {
 	while i < zip.len() {
 		let mut file = zip.by_index(i).unwrap();
 		if file.name().contains("of") {
-			i += 1; continue;
+			i += 1;
+			continue;
 		}
 		if file.name().contains("[53-01-") {
 			let msg: AuthServerMessage = file.read().expect(&format!("Zip: {}, Filename: {}, {} bytes", path.to_str().unwrap(), file.name(), file.size()));
@@ -86,117 +83,105 @@ fn parse(path: &Path, cdclient: &mut Cdclient) -> Res<usize> {
 				std::io::Read::read_to_end(&mut file, &mut rest).unwrap();
 				assert_eq!(rest, vec![], "Zip: {}, Filename: {}, {} bytes", path.to_str().unwrap(), file.name(), file.size());
 			}
-			i += 1; continue
-		} else if file.name().contains("[53-04-")
-			&& !file.name().contains("[53-04-00-16]")
-			&& !file.name().contains("[e6-00]")
-			&& !file.name().contains("[6b-03]")
-			&& !file.name().contains("[16-04]")
-			&& !file.name().contains("[49-04]")
-			&& !file.name().contains("[ad-04]")
-			&& !file.name().contains("[1c-05]")
-			&& !file.name().contains("[230]")
-			&& !file.name().contains("[875]")
-			&& !file.name().contains("[1046]")
-			&& !file.name().contains("[1097]")
-			&& !file.name().contains("[1197]")
-			&& !file.name().contains("[1308]")
-		{
+			i += 1;
+			continue;
+		} else if file.name().contains("[53-04-") && !file.name().contains("[53-04-00-16]") && !file.name().contains("[e6-00]") && !file.name().contains("[6b-03]") && !file.name().contains("[16-04]") && !file.name().contains("[49-04]") && !file.name().contains("[ad-04]") && !file.name().contains("[1c-05]") && !file.name().contains("[230]") && !file.name().contains("[875]") && !file.name().contains("[1046]") && !file.name().contains("[1097]") && !file.name().contains("[1197]") && !file.name().contains("[1308]") {
 			let msg: WorldServerMessage = file.read().expect(&format!("Zip: {}, Filename: {}, {} bytes", path.to_str().unwrap(), file.name(), file.size()));
 			if unsafe { PRINT_PACKETS } {
 				dbg!(&msg);
 			}
 			packet_count += 1;
-		} else if file.name().contains("[53-02-") || (file.name().contains("[53-05-")
-		&& !file.name().contains("[53-05-00-00]")
-		&& !file.name().contains("[53-05-00-31]")
-		&& !file.name().contains("[e6-00]")
-		&& !file.name().contains("[ff-00]")
-		&& !file.name().contains("[a1-01]")
-		&& !file.name().contains("[7f-02]")
-		&& !file.name().contains("[a3-02]")
-		&& !file.name().contains("[cc-02]")
-		&& !file.name().contains("[35-03]")
-		&& !file.name().contains("[36-03]")
-		&& !file.name().contains("[4d-03]")
-		&& !file.name().contains("[6d-03]")
-		&& !file.name().contains("[91-03]")
-		&& !file.name().contains("[1a-05]")
-		&& !file.name().contains("[e6-05]")
-		&& !file.name().contains("[16-06]")
-		&& !file.name().contains("[1c-06]")
-		&& !file.name().contains("[6f-06]")
-		&& !file.name().contains("[70-06]")
-		&& !file.name().contains("[118]")
-		&& !file.name().contains("[230]")
-		&& !file.name().contains("[255]")
-		&& !file.name().contains("[417]")
-		&& !file.name().contains("[639]")
-		&& !file.name().contains("[675]")
-		&& !file.name().contains("[716]")
-		&& !file.name().contains("[821]")
-		&& !file.name().contains("[822]")
-		&& !file.name().contains("[845]")
-		&& !file.name().contains("[877]")
-		&& !file.name().contains("[913]")
-		&& !file.name().contains("[1306]")
-		&& !file.name().contains("[1510]")
-		&& !file.name().contains("[1558]")
-		&& !file.name().contains("[1564]")
-		&& !file.name().contains("[1647]")
-		&& !file.name().contains("[1648]"))
-		|| (file.name().contains("[24]")
-		&& !file.name().contains("(2365)")
-		&& !file.name().contains("(4734)")
-		&& !file.name().contains("(4930)")
-		&& !file.name().contains("(4955)")
-		&& !file.name().contains("(4967)")
-		&& !file.name().contains("(4990)")
-		&& !file.name().contains("(5635)")
-		&& !file.name().contains("(5651)")
-		&& !file.name().contains("(5652)")
-		&& !file.name().contains("(5903)")
-		&& !file.name().contains("(5904)")
-		&& !file.name().contains("(5958)")
-		&& !file.name().contains("(6007)")
-		&& !file.name().contains("(6010)")
-		&& !file.name().contains("(6097)")
-		&& !file.name().contains("(6209)")
-		&& !file.name().contains("(6267)")
-		&& !file.name().contains("(6289)")
-		&& !file.name().contains("(6290)")
-		&& !file.name().contains("(6319)")
-		&& !file.name().contains("(7001)")
-		&& !file.name().contains("(7100)")
-		&& !file.name().contains("(7282)")
-		&& !file.name().contains("(7796)")
-		&& !file.name().contains("(8304)")
-		&& !file.name().contains("(8575)")
-		&& !file.name().contains("(9741)")
-		&& !file.name().contains("(10039)")
-		&& !file.name().contains("(10042)")
-		&& !file.name().contains("(10046)")
-		&& !file.name().contains("(10055)")
-		&& !file.name().contains("(10097)")
-		&& !file.name().contains("(12916)")
-		&& !file.name().contains("(13773)")
-		&& !file.name().contains("(14376)")
-		&& !file.name().contains("(14447)")
-		&& !file.name().contains("(14449)")
-		&& !file.name().contains("(14476)")
-		&& !file.name().contains("(14477)")
-		&& !file.name().contains("(14505)")
-		&& !file.name().contains("(14510)")
-		&& !file.name().contains("(14539)")
-		&& !file.name().contains("(14540)")
-		&& !file.name().contains("(14541)")
-		&& !file.name().contains("(14542)")
-		&& !file.name().contains("(14543)")
-		&& !file.name().contains("(14544)")
-		&& !file.name().contains("(14545)")
-		&& !file.name().contains("(14546)")
-		&& !file.name().contains("(14547)"))
-		|| file.name().contains("[27]")
+		} else if file.name().contains("[53-02-")
+			|| (file.name().contains("[53-05-")
+				&& !file.name().contains("[53-05-00-00]")
+				&& !file.name().contains("[53-05-00-31]")
+				&& !file.name().contains("[e6-00]")
+				&& !file.name().contains("[ff-00]")
+				&& !file.name().contains("[a1-01]")
+				&& !file.name().contains("[7f-02]")
+				&& !file.name().contains("[a3-02]")
+				&& !file.name().contains("[cc-02]")
+				&& !file.name().contains("[35-03]")
+				&& !file.name().contains("[36-03]")
+				&& !file.name().contains("[4d-03]")
+				&& !file.name().contains("[6d-03]")
+				&& !file.name().contains("[91-03]")
+				&& !file.name().contains("[1a-05]")
+				&& !file.name().contains("[e6-05]")
+				&& !file.name().contains("[16-06]")
+				&& !file.name().contains("[1c-06]")
+				&& !file.name().contains("[6f-06]")
+				&& !file.name().contains("[70-06]")
+				&& !file.name().contains("[118]")
+				&& !file.name().contains("[230]")
+				&& !file.name().contains("[255]")
+				&& !file.name().contains("[417]")
+				&& !file.name().contains("[639]")
+				&& !file.name().contains("[675]")
+				&& !file.name().contains("[716]")
+				&& !file.name().contains("[821]")
+				&& !file.name().contains("[822]")
+				&& !file.name().contains("[845]")
+				&& !file.name().contains("[877]")
+				&& !file.name().contains("[913]")
+				&& !file.name().contains("[1306]")
+				&& !file.name().contains("[1510]")
+				&& !file.name().contains("[1558]")
+				&& !file.name().contains("[1564]")
+				&& !file.name().contains("[1647]")
+				&& !file.name().contains("[1648]"))
+			|| (file.name().contains("[24]")
+				&& !file.name().contains("(2365)")
+				&& !file.name().contains("(4734)")
+				&& !file.name().contains("(4930)")
+				&& !file.name().contains("(4955)")
+				&& !file.name().contains("(4967)")
+				&& !file.name().contains("(4990)")
+				&& !file.name().contains("(5635)")
+				&& !file.name().contains("(5651)")
+				&& !file.name().contains("(5652)")
+				&& !file.name().contains("(5903)")
+				&& !file.name().contains("(5904)")
+				&& !file.name().contains("(5958)")
+				&& !file.name().contains("(6007)")
+				&& !file.name().contains("(6010)")
+				&& !file.name().contains("(6097)")
+				&& !file.name().contains("(6209)")
+				&& !file.name().contains("(6267)")
+				&& !file.name().contains("(6289)")
+				&& !file.name().contains("(6290)")
+				&& !file.name().contains("(6319)")
+				&& !file.name().contains("(7001)")
+				&& !file.name().contains("(7100)")
+				&& !file.name().contains("(7282)")
+				&& !file.name().contains("(7796)")
+				&& !file.name().contains("(8304)")
+				&& !file.name().contains("(8575)")
+				&& !file.name().contains("(9741)")
+				&& !file.name().contains("(10039)")
+				&& !file.name().contains("(10042)")
+				&& !file.name().contains("(10046)")
+				&& !file.name().contains("(10055)")
+				&& !file.name().contains("(10097)")
+				&& !file.name().contains("(12916)")
+				&& !file.name().contains("(13773)")
+				&& !file.name().contains("(14376)")
+				&& !file.name().contains("(14447)")
+				&& !file.name().contains("(14449)")
+				&& !file.name().contains("(14476)")
+				&& !file.name().contains("(14477)")
+				&& !file.name().contains("(14505)")
+				&& !file.name().contains("(14510)")
+				&& !file.name().contains("(14539)")
+				&& !file.name().contains("(14540)")
+				&& !file.name().contains("(14541)")
+				&& !file.name().contains("(14542)")
+				&& !file.name().contains("(14543)")
+				&& !file.name().contains("(14544)")
+				&& !file.name().contains("(14545)")
+				&& !file.name().contains("(14546)")
+				&& !file.name().contains("(14547)"))
+			|| file.name().contains("[27]")
 		{
 			let mut ctx = ZipContext { zip: file, comps: &mut comps, cdclient, assert_fully_read: true };
 			let msg: WorldClientMessage = ctx.read().expect(&format!("Zip: {}, Filename: {}, {} bytes", path.to_str().unwrap(), ctx.zip.name(), ctx.zip.size()));
@@ -212,8 +197,12 @@ fn parse(path: &Path, cdclient: &mut Cdclient) -> Res<usize> {
 				std::io::Read::read_to_end(&mut file, &mut rest).unwrap();
 				assert_eq!(rest, vec![], "Zip: {}, Filename: {}, {} bytes", path.to_str().unwrap(), file.name(), file.size());
 			}
-			i += 1; continue
-		} else { i += 1; continue }
+			i += 1;
+			continue;
+		} else {
+			i += 1;
+			continue;
+		}
 		// assert fully read
 		let mut rest = vec![];
 		std::io::Read::read_to_end(&mut file, &mut rest).unwrap();
@@ -231,14 +220,12 @@ fn main() {
 	}
 	let capture = fs::canonicalize(&args[1]).unwrap();
 	let mut cdclient = Cdclient { conn: Connection::open(&args[2]).unwrap(), comp_cache: HashMap::new() };
-	unsafe { PRINT_PACKETS = args.get(3).is_some(); }
+	unsafe {
+		PRINT_PACKETS = args.get(3).is_some();
+	}
 
 	let start = Instant::now();
-	let packet_count = if !capture.is_dir() &&  capture.extension().unwrap() == "zip" {
-		parse(&capture, &mut cdclient)
-	} else {
-		visit_dirs(&capture, &mut cdclient, 0)
-	}.unwrap();
+	let packet_count = if !capture.is_dir() && capture.extension().unwrap() == "zip" { parse(&capture, &mut cdclient) } else { visit_dirs(&capture, &mut cdclient, 0) }.unwrap();
 	println!();
 	println!("Number of parsed packets: {}", packet_count);
 	println!("Time taken: {:?}", start.elapsed());

--- a/examples/capture_parser/zip_context.rs
+++ b/examples/capture_parser/zip_context.rs
@@ -114,6 +114,7 @@ impl ZipContext<'_> {
 		}
 	}
 
+	#[rustfmt::skip]
 	fn map_constrs<R: std::io::Read>(comps: &Vec<u32>) -> Vec<fn(&mut BEBitReader<R>) -> Res<Box<dyn ComponentConstruction>>> {
 		use endio::Deserialize;
 
@@ -186,6 +187,7 @@ impl ReplicaContext for ZipContext<'_> {
 		constrs
 	}
 
+	#[rustfmt::skip]
 	fn get_comp_serializations<R: std::io::Read>(&mut self, network_id: u16) -> Vec<fn(&mut BEBitReader<R>) -> Res<Box<dyn ComponentSerialization>>> {
 		use endio::Deserialize;
 

--- a/examples/capture_parser/zip_context.rs
+++ b/examples/capture_parser/zip_context.rs
@@ -60,12 +60,10 @@ impl ZipContext<'_> {
 	fn apply_whitelist(comps: &mut Vec<u32>, config: &Option<LuNameValue>) {
 		if let Some(conf) = config {
 			if let Some(LnvValue::I32(1)) = conf.get(&lu!("componentWhitelist")) {
-				comps.retain(|&x|
-					match x  {
-						1 | 2 | 3 | 7 | 10 | 11 | 24 | 42 => true,
-						_ => false,
-					}
-				);
+				comps.retain(|&x| match x {
+					1 | 2 | 3 | 7 | 10 | 11 | 24 | 42 => true,
+					_ => false,
+				});
 			}
 		}
 	}
@@ -95,15 +93,23 @@ impl ZipContext<'_> {
 		for comp in comps {
 			// special case: utter bodge
 			match comp {
-				2  => { final_comps.push(44); }
-				4  => { final_comps.push(110); final_comps.push(109); final_comps.push(106); }
-				7  => { final_comps.push(98); }
+				2 => {
+					final_comps.push(44);
+				}
+				4 => {
+					final_comps.push(110);
+					final_comps.push(109);
+					final_comps.push(106);
+				}
+				7 => {
+					final_comps.push(98);
+				}
 				23 | 48 => {
 					if !final_comps.contains(&7) {
 						final_comps.push(7);
 					}
 				}
-				_ => {},
+				_ => {}
 			}
 			final_comps.push(*comp);
 		}

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,7 @@
+unstable_features = true
+hard_tabs = true
+reorder_imports = false
+reorder_modules = false
+# disable line wrapping
+max_width = 1000
+use_small_heuristics = "Max"

--- a/src/auth/client/mod.rs
+++ b/src/auth/client/mod.rs
@@ -41,7 +41,7 @@ impl From<DisconnectNotify> for Message {
 
 /// All client-received auth messages.
 #[derive(Debug, MessageFromVariants, PartialEq, Serialize, Deserialize)]
-#[post_disc_padding=1]
+#[post_disc_padding = 1]
 #[repr(u32)]
 pub enum ClientMessage {
 	LoginResponse(LoginResponse),
@@ -131,21 +131,7 @@ where
 		let disc = unsafe { *(self as *const LoginResponse as *const u8) };
 		writer.write(disc)?;
 		match self {
-			LoginResponse::Ok {
-				events,
-				version,
-				session_key,
-				redirect_address,
-				chat_server_address,
-				cdn_key,
-				cdn_ticket,
-				language,
-				country_code,
-				just_upgraded_from_ftp,
-				is_ftp,
-				time_remaining_in_ftp,
-				stamps,
-			} => {
+			LoginResponse::Ok { events, version, session_key, redirect_address, chat_server_address, cdn_key, cdn_ticket, language, country_code, just_upgraded_from_ftp, is_ftp, time_remaining_in_ftp, stamps } => {
 				writer.write(&events.0)?;
 				writer.write(&events.1)?;
 				writer.write(&events.2)?;
@@ -195,14 +181,8 @@ impl<R: Read + LERead> Deserialize<LE, R> for LoginResponse {
 		let disc = LERead::read::<u8>(reader)?;
 		match disc {
 			1 => {
-				let events: (LuString33, LuString33, LuString33, LuString33, LuString33, LuString33, LuString33, LuString33) 
-					= (LERead::read(reader)?, LERead::read(reader)?, LERead::read(reader)?, LERead::read(reader)?, 
-					LERead::read(reader)?, LERead::read(reader)?, LERead::read(reader)?, LERead::read(reader)?);
-				let version: (u16, u16, u16) = (
-					LERead::read(reader)?,
-					LERead::read(reader)?,
-					LERead::read(reader)?,
-				);
+				let events: (LuString33, LuString33, LuString33, LuString33, LuString33, LuString33, LuString33, LuString33) = (LERead::read(reader)?, LERead::read(reader)?, LERead::read(reader)?, LERead::read(reader)?, LERead::read(reader)?, LERead::read(reader)?, LERead::read(reader)?, LERead::read(reader)?);
+				let version: (u16, u16, u16) = (LERead::read(reader)?, LERead::read(reader)?, LERead::read(reader)?);
 				let session_key: LuWString33 = LERead::read(reader)?;
 				let redirect_address: LuString33 = LERead::read(reader)?;
 				let chat_address: LuString33 = LERead::read(reader)?;
@@ -223,21 +203,7 @@ impl<R: Read + LERead> Deserialize<LE, R> for LoginResponse {
 					let stamp: Stamp = LERead::read(reader)?;
 					stamps.push(stamp);
 				}
-				Ok(Self::Ok {
-					events,
-					version,
-					session_key,
-					redirect_address: (redirect_address, redirect_port),
-					chat_server_address: (chat_address, chat_port),
-					cdn_key,
-					cdn_ticket,
-					language,
-					country_code,
-					just_upgraded_from_ftp,
-					is_ftp,
-					time_remaining_in_ftp,
-					stamps,
-				})
+				Ok(Self::Ok { events, version, session_key, redirect_address: (redirect_address, redirect_port), chat_server_address: (chat_address, chat_port), cdn_key, cdn_ticket, language, country_code, just_upgraded_from_ftp, is_ftp, time_remaining_in_ftp, stamps })
 			}
 			5 => {
 				let mut padding = [0; 493];

--- a/src/auth/server/mod.rs
+++ b/src/auth/server/mod.rs
@@ -19,10 +19,10 @@ pub enum LuMessage {
 
 /// All server-received auth messages.
 #[derive(Debug, Deserialize, PartialEq, Serialize, VariantTests)]
-#[post_disc_padding=1]
+#[post_disc_padding = 1]
 #[repr(u32)]
 pub enum AuthMessage {
-	LoginRequest(LoginRequest)
+	LoginRequest(LoginRequest),
 }
 
 /**

--- a/src/chat/client/mod.rs
+++ b/src/chat/client/mod.rs
@@ -7,7 +7,7 @@ pub use super::{GeneralChatMessage, PrivateChatMessage};
 
 #[derive(Debug, Deserialize, PartialEq, Serialize, MessageFromVariants, VariantTests)]
 #[non_exhaustive]
-#[post_disc_padding=9]
+#[post_disc_padding = 9]
 #[repr(u32)]
 pub enum ChatMessage {
 	GeneralChatMessage(GeneralChatMessage) = 1,
@@ -17,12 +17,12 @@ pub enum ChatMessage {
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct AchievementNotify {
-	#[padding=5]
+	#[padding = 5]
 	pub sender_name: LuWString33,
 	pub sender: ObjId,
 	pub source_id: u16,
 	pub sender_gm_level: u8,
-	pub target_group: u32, // todo: type?
+	pub target_group: u32,        // todo: type?
 	pub mission_message_key: u32, // todo: type?
 	pub requesting_player: ObjId,
 	pub recipient_name: LuWString33,

--- a/src/chat/mod.rs
+++ b/src/chat/mod.rs
@@ -48,12 +48,14 @@ pub struct GeneralChatMessage {
 	pub message: LuVarWString<u32>,
 }
 
-impl<R: Read+LERead> Deserialize<LE, R> for GeneralChatMessage
-	where   u8: Deserialize<LE, R>,
-	       u16: Deserialize<LE, R>,
-	       u32: Deserialize<LE, R>,
-	  LuWString33: Deserialize<LE, R>,
-	     ObjId: Deserialize<LE, R> {
+impl<R: Read + LERead> Deserialize<LE, R> for GeneralChatMessage
+where
+	u8: Deserialize<LE, R>,
+	u16: Deserialize<LE, R>,
+	u32: Deserialize<LE, R>,
+	LuWString33: Deserialize<LE, R>,
+	ObjId: Deserialize<LE, R>,
+{
 	#[rustfmt::skip]
 	fn deserialize(reader: &mut R) -> Res<Self> {
 		let chat_channel     = LERead::read(reader)?;
@@ -71,12 +73,14 @@ impl<R: Read+LERead> Deserialize<LE, R> for GeneralChatMessage
 	}
 }
 
-impl<'a, W: Write+LEWrite> Serialize<LE, W> for &'a GeneralChatMessage
-	where       u8: Serialize<LE, W>,
-	           u16: Serialize<LE, W>,
-	           u32: Serialize<LE, W>,
-	  &'a LuWString33: Serialize<LE, W>,
-	         ObjId: Serialize<LE, W> {
+impl<'a, W: Write + LEWrite> Serialize<LE, W> for &'a GeneralChatMessage
+where
+	u8: Serialize<LE, W>,
+	u16: Serialize<LE, W>,
+	u32: Serialize<LE, W>,
+	&'a LuWString33: Serialize<LE, W>,
+	ObjId: Serialize<LE, W>,
+{
 	fn serialize(self, writer: &mut W) -> Res<()> {
 		LEWrite::write(writer, &self.chat_channel)?;
 		let mut str_len = self.message.len();
@@ -118,13 +122,15 @@ pub struct PrivateChatMessage {
 	pub message: LuVarWString<u32>,
 }
 
-impl<R: Read+LERead> Deserialize<LE, R> for PrivateChatMessage
-	where   u8: Deserialize<LE, R>,
-	       u16: Deserialize<LE, R>,
-	       u32: Deserialize<LE, R>,
-	  LuWString33: Deserialize<LE, R>,
-	     ObjId: Deserialize<LE, R>,
-	  PrivateChatMessageResponseCode: Deserialize<LE, R> {
+impl<R: Read + LERead> Deserialize<LE, R> for PrivateChatMessage
+where
+	u8: Deserialize<LE, R>,
+	u16: Deserialize<LE, R>,
+	u32: Deserialize<LE, R>,
+	LuWString33: Deserialize<LE, R>,
+	ObjId: Deserialize<LE, R>,
+	PrivateChatMessageResponseCode: Deserialize<LE, R>,
+{
 	#[rustfmt::skip]
 	fn deserialize(reader: &mut R) -> Res<Self> {
 		let chat_channel       = LERead::read(reader)?;
@@ -142,13 +148,15 @@ impl<R: Read+LERead> Deserialize<LE, R> for PrivateChatMessage
 		Ok(Self { chat_channel, sender_name, sender, source_id, sender_gm_level, recipient_name, recipient_gm_level, response_code, message })
 	}
 }
-impl<'a, W: Write+LEWrite> Serialize<LE, W> for &'a PrivateChatMessage
-	where       u8: Serialize<LE, W>,
-	           u16: Serialize<LE, W>,
-	           u32: Serialize<LE, W>,
-	  &'a LuWString33: Serialize<LE, W>,
-	         ObjId: Serialize<LE, W>,
-	  &'a PrivateChatMessageResponseCode: Serialize<LE, W> {
+impl<'a, W: Write + LEWrite> Serialize<LE, W> for &'a PrivateChatMessage
+where
+	u8: Serialize<LE, W>,
+	u16: Serialize<LE, W>,
+	u32: Serialize<LE, W>,
+	&'a LuWString33: Serialize<LE, W>,
+	ObjId: Serialize<LE, W>,
+	&'a PrivateChatMessageResponseCode: Serialize<LE, W>,
+{
 	fn serialize(self, writer: &mut W) -> Res<()> {
 		LEWrite::write(writer, &self.chat_channel)?;
 		let mut str_len = self.message.len();

--- a/src/chat/mod.rs
+++ b/src/chat/mod.rs
@@ -54,6 +54,7 @@ impl<R: Read+LERead> Deserialize<LE, R> for GeneralChatMessage
 	       u32: Deserialize<LE, R>,
 	  LuWString33: Deserialize<LE, R>,
 	     ObjId: Deserialize<LE, R> {
+	#[rustfmt::skip]
 	fn deserialize(reader: &mut R) -> Res<Self> {
 		let chat_channel     = LERead::read(reader)?;
 		let mut str_len: u32 = LERead::read(reader)?;
@@ -124,6 +125,7 @@ impl<R: Read+LERead> Deserialize<LE, R> for PrivateChatMessage
 	  LuWString33: Deserialize<LE, R>,
 	     ObjId: Deserialize<LE, R>,
 	  PrivateChatMessageResponseCode: Deserialize<LE, R> {
+	#[rustfmt::skip]
 	fn deserialize(reader: &mut R) -> Res<Self> {
 		let chat_channel       = LERead::read(reader)?;
 		let mut str_len: u32       = LERead::read(reader)?;

--- a/src/chat/server/mod.rs
+++ b/src/chat/server/mod.rs
@@ -6,7 +6,7 @@ pub use super::{GeneralChatMessage, PrivateChatMessage};
 use super::ChatChannel;
 
 #[derive(Debug, Deserialize, PartialEq, Serialize, VariantTests)]
-#[post_disc_padding=9]
+#[post_disc_padding = 9]
 #[repr(u32)]
 pub enum ChatMessage {
 	GeneralChatMessage(GeneralChatMessage) = 1,

--- a/src/common/mod.rs
+++ b/src/common/mod.rs
@@ -32,7 +32,11 @@ impl<L, T> LVec<L, T> {
 		&self.0
 	}
 
-	pub(crate) fn deser_content<R: Read>(reader: &mut R, len: L) -> Res<Self> where L: TryInto<usize>, T: Deserialize<LE, R> {
+	pub(crate) fn deser_content<R: Read>(reader: &mut R, len: L) -> Res<Self>
+	where
+		L: TryInto<usize>,
+		T: Deserialize<LE, R>,
+	{
 		let len = match len.try_into() {
 			Ok(x) => x,
 			_ => panic!(),
@@ -44,7 +48,10 @@ impl<L, T> LVec<L, T> {
 		Ok(Self(vec, PhantomData))
 	}
 
-	pub(crate) fn ser_len<W: LEWrite>(&self, writer: &mut W) -> Res<()> where L: TryFrom<usize> + Serialize<LE, W> {
+	pub(crate) fn ser_len<W: LEWrite>(&self, writer: &mut W) -> Res<()>
+	where
+		L: TryFrom<usize> + Serialize<LE, W>,
+	{
 		let len = self.0.len();
 		let l_len = match L::try_from(len) {
 			Ok(x) => x,
@@ -53,7 +60,10 @@ impl<L, T> LVec<L, T> {
 		writer.write(l_len)
 	}
 
-	pub(crate) fn ser_content<W: Write>(&self, writer: &mut W) -> Res<()> where for<'a> &'a T: Serialize<LE, W> {
+	pub(crate) fn ser_content<W: Write>(&self, writer: &mut W) -> Res<()>
+	where
+		for<'a> &'a T: Serialize<LE, W>,
+	{
 		for e in &self.0 {
 			LEWrite::write(writer, e)?;
 		}
@@ -68,9 +78,10 @@ impl<L, T: Debug> Debug for LVec<L, T> {
 }
 
 impl<L, T, R: Read> Deserialize<LE, R> for LVec<L, T>
-	where L: TryInto<usize> + Deserialize<LE, R>,
-	      T: Deserialize<LE, R>	{
-
+where
+	L: TryInto<usize> + Deserialize<LE, R>,
+	T: Deserialize<LE, R>,
+{
 	fn deserialize(reader: &mut R) -> Res<Self> {
 		let len: L = LERead::read(reader)?;
 		Self::deser_content(reader, len)
@@ -78,9 +89,10 @@ impl<L, T, R: Read> Deserialize<LE, R> for LVec<L, T>
 }
 
 impl<'a, L, T, W: Write> Serialize<LE, W> for &'a LVec<L, T>
-	where L: TryFrom<usize> + Serialize<LE, W>,
-	  for<'b> &'b T: Serialize<LE, W> {
-
+where
+	L: TryFrom<usize> + Serialize<LE, W>,
+	for<'b> &'b T: Serialize<LE, W>,
+{
 	fn serialize(self, writer: &mut W) -> Res<()> {
 		self.ser_len(writer)?;
 		self.ser_content(writer)
@@ -108,7 +120,6 @@ impl<L, T> From<Vec<T>> for LVec<L, T> {
 		Self(vec, PhantomData)
 	}
 }
-
 
 #[derive(Debug, PartialEq, Deserialize, Serialize)]
 #[repr(u16)]

--- a/src/common/str/fixed.rs
+++ b/src/common/str/fixed.rs
@@ -46,7 +46,7 @@ macro_rules! abstract_lu_str {
 
 		impl<R: Read> Deserialize<LE, R> for $name {
 			fn deserialize(reader: &mut R) -> Res<Self> {
-				let mut bytes = [0u8; $n*std::mem::size_of::<$c>()];
+				let mut bytes = [0u8; $n * std::mem::size_of::<$c>()];
 				reader.read(&mut bytes)?;
 				Ok(Self(unsafe { std::mem::transmute(bytes) }))
 			}
@@ -54,11 +54,11 @@ macro_rules! abstract_lu_str {
 
 		impl<W: Write> Serialize<LE, W> for &$name {
 			fn serialize(self, writer: &mut W) -> Res<()> {
-				let x: [u8; $n*std::mem::size_of::<$c>()] = unsafe { std::mem::transmute(self.0) };
+				let x: [u8; $n * std::mem::size_of::<$c>()] = unsafe { std::mem::transmute(self.0) };
 				writer.write_all(&x)
 			}
 		}
-	}
+	};
 }
 
 macro_rules! lu_str {
@@ -90,7 +90,7 @@ macro_rules! lu_str {
 				Self::try_from(&string[..])
 			}
 		}
-	}
+	};
 }
 
 macro_rules! lu_wstr {
@@ -102,7 +102,7 @@ macro_rules! lu_wstr {
 
 			fn try_from(string: &str) -> Result<Self, Self::Error> {
 				let mut bytes = [0u16; $n];
-				for (i, chr) in string.encode_utf16().take($n-1).enumerate() {
+				for (i, chr) in string.encode_utf16().take($n - 1).enumerate() {
 					bytes[i] = chr;
 				}
 				let bytes = unsafe { std::mem::transmute(bytes) };
@@ -112,10 +112,10 @@ macro_rules! lu_wstr {
 
 		impl From<&$name> for String {
 			fn from(wstr: &$name) -> Self {
-				String::from_utf16(unsafe {&*(&**wstr as *const [Ucs2Char] as *const [<Ucs2Char as LuChar>::Int])}).unwrap()
+				String::from_utf16(unsafe { &*(&**wstr as *const [Ucs2Char] as *const [<Ucs2Char as LuChar>::Int]) }).unwrap()
 			}
 		}
-	}
+	};
 }
 
 lu_str!(LuString3, 3);

--- a/src/general/client/mod.rs
+++ b/src/general/client/mod.rs
@@ -6,7 +6,7 @@ use crate::common::ServiceId;
 
 /// Client-received general messages.
 #[derive(Debug, Deserialize, PartialEq, Serialize, VariantTests)]
-#[post_disc_padding=1]
+#[post_disc_padding = 1]
 #[repr(u32)]
 pub enum GeneralMessage {
 	Handshake(Handshake),
@@ -29,12 +29,12 @@ pub enum GeneralMessage {
 	As the version confirm process was designed with more than just client-server in mind, it sends the server's network version and service id as well, even though this isn't really needed by the client (even the service id isn't needed, since you usually only connect to auth once, and it's the very first connection). This could be simplified if the protocol is ever revised.
 */
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
-#[trailing_padding=41]
+#[trailing_padding = 41]
 pub struct Handshake {
 	/// The network protocol version of the server. For servers compatible with live, this is `171022`. This was relevant mainly back when LU was actively updated. Server projects making modifications to the network protocol should set this to a different value.
 	pub network_version: u32,
 	/// Service ID of the server, [`ServiceId::Auth`] for auth servers, [`ServiceId::World`] for world servers.
-	#[padding=4]
+	#[padding = 4]
 	pub service_id: ServiceId,
 }
 

--- a/src/general/server/mod.rs
+++ b/src/general/server/mod.rs
@@ -5,10 +5,10 @@ use lu_packets_derive::VariantTests;
 use crate::common::ServiceId;
 
 #[derive(Debug, Deserialize, PartialEq, Serialize, VariantTests)]
-#[post_disc_padding=1]
+#[post_disc_padding = 1]
 #[repr(u32)]
 pub enum GeneralMessage {
-	Handshake(Handshake)
+	Handshake(Handshake),
 }
 
 /**
@@ -29,14 +29,14 @@ pub enum GeneralMessage {
 	This packet should not be seen as proof that the client's network version is actually what they report it to be. The client can provide any value, and malicious clients can deviate from the protocol in any way they like. Therefore, proper length and value checking is still required for packet parsing, and care should be taken that your server does not crash on invalid input. If you're using the parsing functionality of this library, this will be taken care of for you.
 */
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
-#[trailing_padding=33]
+#[trailing_padding = 33]
 pub struct Handshake {
 	/// The network protocol version of the client. For unmodified live clients, this is `171022`. This was relevant mainly back when LU was actively updated. If you intend to make modifications to the protocol for your server project, you should change this to a different value.
 	pub network_version: u32,
-	#[padding=4]
+	#[padding = 4]
 	/// Service ID of the client, always [`ServiceId::Client`]. LU used this packet for all service communications, including server-to-server, which is the reason it's necessary to specify this.
 	pub service_id: ServiceId,
-	#[padding=2]
+	#[padding = 2]
 	/// Process ID of the client.
 	pub process_id: u32,
 	/// Local port of the client, not necessarily the same as the one the connection is from in case of NAT.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -130,7 +130,7 @@ macro_rules! lnv {
 macro_rules! lu {
 	($str_lit:expr) => {
 		::std::convert::TryInto::try_into($str_lit).unwrap()
-	}
+	};
 }
 
 pub mod raknet;

--- a/src/raknet/client/mod.rs
+++ b/src/raknet/client/mod.rs
@@ -52,6 +52,6 @@ pub struct ConnectedPong {
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct ConnectionRequestAccepted {
 	pub peer_addr: SystemAddress,
-	#[padding=2]
+	#[padding = 2]
 	pub local_addr: SystemAddress,
 }

--- a/src/raknet/client/replica/buff.rs
+++ b/src/raknet/client/replica/buff.rs
@@ -39,27 +39,9 @@ impl<R: Read> Deserialize<LE, BEBitReader<R>> for BuffInfo {
 		let cancel_on_damage_absorb_ran_out = reader.read_bit()?;
 		let added_by_teammate = reader.read_bit()?;
 		let apply_on_teammates = reader.read_bit()?;
-		let added_by_teammate = if added_by_teammate {
-			Some(LERead::read(reader)?)
-		} else {
-			None
-		};
+		let added_by_teammate = if added_by_teammate { Some(LERead::read(reader)?) } else { None };
 		let ref_count = LERead::read(reader)?;
-		Ok(Self {
-				buff_id,
-				time_left,
-				cancel_on_death,
-				cancel_on_zone,
-				cancel_on_damaged,
-				cancel_on_remove_buff,
-				cancel_on_ui,
-				cancel_on_logout,
-				cancel_on_unequip,
-				cancel_on_damage_absorb_ran_out,
-				added_by_teammate,
-				apply_on_teammates,
-				ref_count,
-		})
+		Ok(Self { buff_id, time_left, cancel_on_death, cancel_on_zone, cancel_on_damaged, cancel_on_remove_buff, cancel_on_ui, cancel_on_logout, cancel_on_unequip, cancel_on_damage_absorb_ran_out, added_by_teammate, apply_on_teammates, ref_count })
 	}
 }
 impl<'a, W: Write> Serialize<LE, BEBitWriter<W>> for &'a BuffInfo {
@@ -91,8 +73,7 @@ pub struct BuffConstruction {
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
-pub struct BuffSerialization {
-}
+pub struct BuffSerialization {}
 
 impl ComponentConstruction for BuffConstruction {
 	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {

--- a/src/raknet/client/replica/character.rs
+++ b/src/raknet/client/replica/character.rs
@@ -21,7 +21,7 @@ impl<R: Read> Deserialize<LE, BEBitReader<R>> for TransitionState {
 			0 => TransitionState::None,
 			1 => TransitionState::Arrive { last_custom_build_parts: LERead::read(reader)? },
 			2 => TransitionState::Leave,
-			_ => { return Err(Error::new(InvalidData, "invalid discriminant for TransitionState")) }
+			_ => return Err(Error::new(InvalidData, "invalid discriminant for TransitionState")),
 		})
 	}
 }
@@ -30,7 +30,10 @@ impl<'a, W: Write> Serialize<LE, BEBitWriter<W>> for &'a TransitionState {
 	fn serialize(self, writer: &mut BEBitWriter<W>) -> Res<()> {
 		match self {
 			TransitionState::None => writer.write_bits(0, 2),
-			TransitionState::Arrive { last_custom_build_parts } => { writer.write_bits(1, 2)?; LEWrite::write(writer, last_custom_build_parts) },
+			TransitionState::Arrive { last_custom_build_parts } => {
+				writer.write_bits(1, 2)?;
+				LEWrite::write(writer, last_custom_build_parts)
+			}
 			TransitionState::Leave => writer.write_bits(2, 2),
 		}
 	}
@@ -57,7 +60,7 @@ pub enum GameActivity {
 }
 
 #[derive(Debug, PartialEq, ReplicaSerde)]
-#[trailing_padding=4] // country code, unused
+#[trailing_padding = 4] // country code, unused
 pub struct SocialInfo {
 	pub guild_id: ObjId,
 	pub guild_name: LuVarWString<u8>,
@@ -73,11 +76,11 @@ pub struct CharacterConstruction {
 	// todo: type for each of the below
 	pub hair_color: u32,
 	pub hair_style: u32,
-	#[padding=4] // head style, unused
+	#[padding = 4] // head style, unused
 	pub torso_color: u32,
 	pub legs_color: u32,
 	pub torso_decal: u32,
-	#[padding=4] // head color, unused
+	#[padding = 4] // head color, unused
 	pub eyebrows_style: u32,
 	pub eyes_style: u32,
 	pub mouth_style: u32,

--- a/src/raknet/client/replica/destroyable.rs
+++ b/src/raknet/client/replica/destroyable.rs
@@ -49,6 +49,7 @@ pub struct StatsInfo {
 }
 
 impl<R: Read> Deserialize<LE, BEBitReader<R>> for StatsInfo {
+	#[rustfmt::skip]
 	fn deserialize(reader: &mut BEBitReader<R>) -> Res<Self> {
 		let cur_health = LERead::read(reader)?;
 		let max_health = LERead::read(reader)?;

--- a/src/raknet/client/replica/fx.rs
+++ b/src/raknet/client/replica/fx.rs
@@ -22,8 +22,7 @@ pub struct FxConstruction {
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
-pub struct FxSerialization {
-}
+pub struct FxSerialization {}
 
 impl ComponentConstruction for FxConstruction {
 	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {

--- a/src/raknet/client/replica/mod.rs
+++ b/src/raknet/client/replica/mod.rs
@@ -157,6 +157,7 @@ impl PartialEq<ReplicaConstruction> for ReplicaConstruction {
 }
 
 impl<R: Read+ReplicaContext> Deserialize<LE, R> for ReplicaConstruction {
+	#[rustfmt::skip]
 	fn deserialize(reader: &mut R) -> Res<Self> {
 		let mut bit_reader = BEBitReader::new(reader);
 		let bit = bit_reader.read_bit()?;

--- a/src/raknet/client/replica/mod.rs
+++ b/src/raknet/client/replica/mod.rs
@@ -57,7 +57,10 @@ impl<R: Read, T: Deserialize<LE, BEBitReader<R>>> ReplicaD<R> for T {
 	}
 }
 
-impl<'a, W: Write, T> ReplicaS<W> for &'a T where &'a T: Serialize<LE, BEBitWriter<W>> {
+impl<'a, W: Write, T> ReplicaS<W> for &'a T
+where
+	&'a T: Serialize<LE, BEBitWriter<W>>,
+{
 	default fn serialize(self, writer: &mut BEBitWriter<W>) -> Res<()> {
 		Serialize::serialize(self, writer)
 	}
@@ -75,18 +78,17 @@ impl<'a, W: Write> ReplicaS<W> for &'a bool {
 	}
 }
 
-impl<R: Read, T: ReplicaD<R>+Deserialize<LE, BEBitReader<R>>> ReplicaD<R> for Option<T> {
+impl<R: Read, T: ReplicaD<R> + Deserialize<LE, BEBitReader<R>>> ReplicaD<R> for Option<T> {
 	fn deserialize(reader: &mut BEBitReader<R>) -> Res<Self> {
 		let bit = reader.read_bit()?;
-		Ok(if !bit {
-			None
-		} else {
-			Some(ReplicaD::deserialize(reader)?)
-		})
+		Ok(if !bit { None } else { Some(ReplicaD::deserialize(reader)?) })
 	}
 }
 
-impl<W: Write, T> ReplicaS<W> for &Option<T> where for<'a> &'a T: ReplicaS<W>+Serialize<LE, BEBitWriter<W>> {
+impl<W: Write, T> ReplicaS<W> for &Option<T>
+where
+	for<'a> &'a T: ReplicaS<W> + Serialize<LE, BEBitWriter<W>>,
+{
 	fn serialize(self, writer: &mut BEBitWriter<W>) -> Res<()> {
 		writer.write_bit(self.is_some())?;
 		if let Some(x) = self {
@@ -144,7 +146,7 @@ pub struct ReplicaConstruction {
 	pub spawner_node_id: Option<i32>,
 	pub scale: Option<f32>,
 	pub world_state: Option<u8>, // todo: type
-	pub gm_level: Option<u8>, // todo: type
+	pub gm_level: Option<u8>,    // todo: type
 	pub parent_child_info: Option<ParentChildInfo>,
 	pub components: Vec<Box<dyn ComponentConstruction>>,
 }
@@ -156,7 +158,7 @@ impl PartialEq<ReplicaConstruction> for ReplicaConstruction {
 	}
 }
 
-impl<R: Read+ReplicaContext> Deserialize<LE, R> for ReplicaConstruction {
+impl<R: Read + ReplicaContext> Deserialize<LE, R> for ReplicaConstruction {
 	#[rustfmt::skip]
 	fn deserialize(reader: &mut R) -> Res<Self> {
 		let mut bit_reader = BEBitReader::new(reader);
@@ -240,7 +242,7 @@ impl PartialEq<ReplicaSerialization> for ReplicaSerialization {
 	}
 }
 
-impl<R: Read+ReplicaContext> Deserialize<LE, R> for ReplicaSerialization {
+impl<R: Read + ReplicaContext> Deserialize<LE, R> for ReplicaSerialization {
 	fn deserialize(reader: &mut R) -> Res<Self> {
 		let network_id = LERead::read(reader)?;
 		let comp_desers = reader.get_comp_serializations(network_id);
@@ -251,11 +253,7 @@ impl<R: Read+ReplicaContext> Deserialize<LE, R> for ReplicaSerialization {
 			components.push(new(&mut bit_reader)?);
 		}
 
-		Ok(Self {
-			network_id,
-			parent_child_info,
-			components,
-		})
+		Ok(Self { network_id, parent_child_info, components })
 	}
 }
 
@@ -277,7 +275,7 @@ impl<'a, W: Write> Serialize<LE, W> for &'a ReplicaSerialization {
 #[cfg(test)]
 #[derive(Debug)]
 pub(super) struct DummyContext<'a> {
-	pub(super) inner: &'a mut &'a[u8],
+	pub(super) inner: &'a mut &'a [u8],
 }
 
 #[cfg(test)]

--- a/src/raknet/client/replica/moving_platform.rs
+++ b/src/raknet/client/replica/moving_platform.rs
@@ -64,11 +64,7 @@ impl<R: Read> Deserialize<LE, BEBitReader<R>> for MovingPlatformConstruction {
 	fn deserialize(reader: &mut BEBitReader<R>) -> Res<Self> {
 		let has_subcomponent_infos = reader.read_bit()?;
 		let flag = reader.read_bit()?;
-		let path_info = if flag {
-			ReplicaD::deserialize(reader)?
-		} else {
-			None
-		};
+		let path_info = if flag { ReplicaD::deserialize(reader)? } else { None };
 		let subcomponent_infos = if has_subcomponent_infos {
 			let mut infos = vec![];
 			while reader.read_bit()? {

--- a/src/raknet/client/replica/racing_control.rs
+++ b/src/raknet/client/replica/racing_control.rs
@@ -80,14 +80,7 @@ impl<R: Read> Deserialize<LE, BEBitReader<R>> for RacingControlConstruction {
 		} else {
 			None
 		};
-		Ok(Self {
-			activity_user_infos,
-			expected_player_count,
-			pre_race_player_infos,
-			post_race_player_infos,
-			race_info,
-			during_race_player_infos,
-		})
+		Ok(Self { activity_user_infos, expected_player_count, pre_race_player_infos, post_race_player_infos, race_info, during_race_player_infos })
 	}
 }
 

--- a/src/raknet/client/replica/script.rs
+++ b/src/raknet/client/replica/script.rs
@@ -13,8 +13,7 @@ pub struct ScriptConstruction {
 }
 
 #[derive(BitVariantTests, Debug, PartialEq, ReplicaSerde)]
-pub struct ScriptSerialization {
-}
+pub struct ScriptSerialization {}
 
 impl ComponentConstruction for ScriptConstruction {
 	fn ser(&self, writer: &mut BEBitWriter<Vec<u8>>) -> Res<()> {

--- a/src/raknet/client/replica/skill.rs
+++ b/src/raknet/client/replica/skill.rs
@@ -25,8 +25,8 @@ pub struct BehaviorInfo {
 #[derive(Debug, PartialEq, ReplicaSerde)]
 pub struct SkillInfo {
 	pub unknown_1: u32,
-	pub skill_id: u32, // todo: type
-	pub cast_type: u32, // todo: type
+	pub skill_id: u32,    // todo: type
+	pub cast_type: u32,   // todo: type
 	pub cancel_type: u32, // todo: type
 	pub behaviors: LVec<u32, BehaviorInfo>,
 }

--- a/src/raknet/server/mod.rs
+++ b/src/raknet/server/mod.rs
@@ -22,12 +22,12 @@ pub enum Message<U> {
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct InternalPing {
-	pub send_time: u32
+	pub send_time: u32,
 }
 
 #[derive(Debug, PartialEq)]
 pub struct ConnectionRequest {
-	pub password: Box<[u8]>
+	pub password: Box<[u8]>,
 }
 
 impl<R: Read> Deserialize<LE, R> for ConnectionRequest {

--- a/src/world/amf3.rs
+++ b/src/world/amf3.rs
@@ -138,7 +138,7 @@ impl<R: Read> Deserialize<LE, Amf3Reader<'_, R>> for Amf3String {
 			let index = value;
 			match reader.string_ref_table.get(index as usize) {
 				Some(x) => x.0.clone(),
-				None => { return Err(Error::new(InvalidData, "invalid reference index")) }
+				None => return Err(Error::new(InvalidData, "invalid reference index")),
 			}
 		} else {
 			let length = value;
@@ -148,7 +148,7 @@ impl<R: Read> Deserialize<LE, Amf3Reader<'_, R>> for Amf3String {
 
 			let string = match String::from_utf8(vec) {
 				Ok(x) => x,
-				Err(_) => { return Err(Error::new(InvalidData, "string is not valid utf8")) }
+				Err(_) => return Err(Error::new(InvalidData, "string is not valid utf8")),
 			};
 			if string != "" {
 				reader.string_ref_table.push(Self(string.clone()));
@@ -251,7 +251,9 @@ impl<R: Read> Deserialize<LE, Amf3Reader<'_, R>> for Amf3Array {
 		let length_and_is_inline: U29 = LERead::read(reader)?;
 		let is_inline = length_and_is_inline.0 & 0x01 == 1;
 		let length = length_and_is_inline.0 >> 1;
-		if !is_inline { todo!() }
+		if !is_inline {
+			todo!()
+		}
 		let mut map = HashMap::new();
 		loop {
 			let key: Amf3String = LERead::read(reader)?;
@@ -336,8 +338,8 @@ fn deser_amf3<R: Read>(reader: &mut Amf3Reader<R>) -> Res<Amf3> {
 		3 => Amf3::True,
 		5 => Amf3::Double(LERead::read(reader)?),
 		6 => Amf3::String(LERead::read(reader)?),
-		9 => Amf3::Array (LERead::read(reader)?),
-		_ => { return Err(Error::new(InvalidData, format!("invalid discriminant value for Amf3: {}", disc))) }
+		9 => Amf3::Array(LERead::read(reader)?),
+		_ => return Err(Error::new(InvalidData, format!("invalid discriminant value for Amf3: {}", disc))),
 	})
 }
 
@@ -361,7 +363,11 @@ fn ser_amf3<W: Write>(writer: &mut Amf3Writer<W>, amf3: &Amf3) -> Res<()> {
 
 impl From<bool> for Amf3 {
 	fn from(b: bool) -> Self {
-		if b { Self::True } else { Self::False }
+		if b {
+			Self::True
+		} else {
+			Self::False
+		}
 	}
 }
 

--- a/src/world/amf3.rs
+++ b/src/world/amf3.rs
@@ -84,11 +84,13 @@ impl<'a, W: Write> Serialize<LE, W> for &'a U29 {
 			LEWrite::write(writer, v as u8 & 0x7f)
 		} else if v <= 0x1fffff {
 			LEWrite::write(writer, (v >> 14) as u8 | 0x80)?;
+			#[rustfmt::skip]
 			LEWrite::write(writer, (v >> 7 ) as u8 | 0x80)?;
 			LEWrite::write(writer, v as u8 & 0x7f)
 		} else {
 			LEWrite::write(writer, (v >> 22) as u8 | 0x80)?;
 			LEWrite::write(writer, (v >> 15) as u8 | 0x80)?;
+			#[rustfmt::skip]
 			LEWrite::write(writer, (v >> 8 ) as u8 | 0x80)?;
 			LEWrite::write(writer, v as u8)
 		}
@@ -308,6 +310,7 @@ pub enum Amf3 {
 }
 
 impl Debug for Amf3 {
+	#[rustfmt::skip]
 	fn fmt(&self, f: &mut Formatter<'_>) -> FmtResult {
 		match self {
 			Self::False     => write!(f, "false"),
@@ -345,6 +348,7 @@ impl<'a, W: Write> Serialize<LE, W> for &'a Amf3 {
 	}
 }
 
+#[rustfmt::skip]
 fn ser_amf3<W: Write>(writer: &mut Amf3Writer<W>, amf3: &Amf3) -> Res<()> {
 	match amf3 {
 		Amf3::False     =>   LEWrite::write(writer, 2u8),

--- a/src/world/client/mod.rs
+++ b/src/world/client/mod.rs
@@ -354,6 +354,7 @@ pub struct AddFriendResponse {
 }
 
 impl<R: Read> Deserialize<LE, R> for AddFriendResponse {
+	#[rustfmt::skip]
 	fn deserialize(reader: &mut R) -> Res<Self>	{
 		let disc: u8       = LERead::read(reader)?;
 		let is_online      = LERead::read(reader)?;

--- a/src/world/client/mod.rs
+++ b/src/world/client/mod.rs
@@ -46,7 +46,7 @@ impl From<DisconnectNotify> for Message {
 /// All client-received world messages.
 #[derive(Debug, Deserialize, PartialEq, Serialize, MessageFromVariants, VariantTests)]
 #[non_exhaustive]
-#[post_disc_padding=1]
+#[post_disc_padding = 1]
 #[repr(u32)]
 pub enum ClientMessage {
 	LoadStaticZone(LoadStaticZone) = 2,
@@ -108,7 +108,7 @@ pub struct LoadStaticZone {
 	/// Checksum on the map on the server side. The original LU client will refuse to load any map where the client side checksum doesn't match the server checksum, to prevent inconsistencies and cheating.
 	pub map_checksum: u32,
 	// editor enabled and editor level, unused
-	#[padding=2]
+	#[padding = 2]
 	/// The position of the player in the new world, likely used to be able to load the right part of the world.
 	pub player_position: Vector3,
 	/// The instance type of the zone being loaded.
@@ -144,23 +144,27 @@ pub struct CharacterListResponse {
 }
 
 impl<R: LERead> Deserialize<LE, R> for CharacterListResponse
-	where       u8: Deserialize<LE, R>,
-	  CharListChar: Deserialize<LE, R> {
-	fn deserialize(reader: &mut R) -> Res<Self>	{
+where
+	u8: Deserialize<LE, R>,
+	CharListChar: Deserialize<LE, R>,
+{
+	fn deserialize(reader: &mut R) -> Res<Self> {
 		let len: u8 = reader.read()?;
 		let selected_char = reader.read()?;
 		let mut chars = Vec::with_capacity(len as usize);
 		for _ in 0..len {
 			chars.push(reader.read()?);
 		}
-		Ok(Self { selected_char, chars } )
+		Ok(Self { selected_char, chars })
 	}
 }
 
 impl<'a, W: LEWrite> Serialize<LE, W> for &'a CharacterListResponse
-	where           u8: Serialize<LE, W>,
-	  &'a CharListChar: Serialize<LE, W> {
-	fn serialize(self, writer: &mut W) -> Res<()>	{
+where
+	u8: Serialize<LE, W>,
+	&'a CharListChar: Serialize<LE, W>,
+{
+	fn serialize(self, writer: &mut W) -> Res<()> {
 		writer.write(self.chars.len() as u8)?;
 		writer.write(self.selected_char)?;
 		for chr in self.chars.iter() {
@@ -174,24 +178,24 @@ impl<'a, W: LEWrite> Serialize<LE, W> for &'a CharacterListResponse
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct CharListChar {
 	pub obj_id: ObjId,
-	#[padding=4]
+	#[padding = 4]
 	pub char_name: LuWString33,
 	pub pending_name: LuWString33,
 	pub requires_rename: bool,
 	pub is_free_trial: bool,
-	#[padding=10]
+	#[padding = 10]
 	pub torso_color: u32,
-	#[padding=4]
+	#[padding = 4]
 	pub legs_color: u32,
 	pub hair_style: u32,
 	pub hair_color: u32,
-	#[padding=8]
+	#[padding = 8]
 	pub eyebrows_style: u32,
 	pub eyes_style: u32,
 	pub mouth_style: u32,
-	#[padding=4]
+	#[padding = 4]
 	pub last_location: ZoneId,
-	#[padding=8]
+	#[padding = 8]
 	pub equipped_items: LVec<u16, Lot>,
 }
 
@@ -322,20 +326,10 @@ pub struct AddFriendRequest {
 #[derive(Debug, PartialEq)]
 #[repr(u8)]
 pub enum AddFriendResponseType {
-	Accepted {
-		is_online: bool,
-		sender_id: ObjId,
-		zone_id: ZoneId,
-		is_best_friend: bool,
-		is_free_trial: bool,
-	},
-	AlreadyFriend {
-		is_best_friend: bool,
-	},
+	Accepted { is_online: bool, sender_id: ObjId, zone_id: ZoneId, is_best_friend: bool, is_free_trial: bool },
+	AlreadyFriend { is_best_friend: bool },
 	InvalidCharacter,
-	GeneralError {
-		is_best_friend: bool,
-	},
+	GeneralError { is_best_friend: bool },
 	YourFriendListFull,
 	TheirFriendListFull,
 	Declined,
@@ -385,7 +379,7 @@ impl<R: Read> Deserialize<LE, R> for AddFriendResponse {
 }
 
 impl<'a, W: Write> Serialize<LE, W> for &'a AddFriendResponse {
-	fn serialize(self, writer: &mut W) -> Res<()>	{
+	fn serialize(self, writer: &mut W) -> Res<()> {
 		let disc = unsafe { *(&self.response_type as *const AddFriendResponseType as *const u8) };
 		LEWrite::write(writer, disc)?;
 		let mut is_online_x = &false;
@@ -407,7 +401,7 @@ impl<'a, W: Write> Serialize<LE, W> for &'a AddFriendResponse {
 			AddFriendResponseType::GeneralError { is_best_friend } => {
 				is_best_friend_x = is_best_friend;
 			}
-			_ => {},
+			_ => {}
 		}
 		LEWrite::write(writer, is_online_x)?;
 		LEWrite::write(writer, &self.char_name)?;
@@ -420,12 +414,12 @@ impl<'a, W: Write> Serialize<LE, W> for &'a AddFriendResponse {
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
-#[trailing_padding=6]
+#[trailing_padding = 6]
 pub struct FriendState {
 	pub is_online: bool,
 	pub is_best_friend: bool,
 	pub is_free_trial: bool,
-	#[padding=5]
+	#[padding = 5]
 	pub location: ZoneId,
 	pub object_id: ObjId,
 	pub char_name: LuWString33,
@@ -433,7 +427,7 @@ pub struct FriendState {
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[repr(u8)]
-#[post_disc_padding=2]
+#[post_disc_padding = 2]
 pub enum GetFriendsListResponse {
 	Ok(LVec<u16, FriendState>),
 	GeneralError,
@@ -458,7 +452,7 @@ pub struct FriendUpdateNotify {
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
-#[trailing_padding=6]
+#[trailing_padding = 6]
 pub struct IgnoreState {
 	pub object_id: ObjId,
 	pub char_name: LuWString33,
@@ -466,7 +460,7 @@ pub struct IgnoreState {
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 #[repr(u8)]
-#[post_disc_padding=2]
+#[post_disc_padding = 2]
 pub enum GetIgnoreListResponse {
 	Ok(LVec<u16, IgnoreState>),
 	GeneralError,
@@ -521,8 +515,8 @@ pub struct ChatModerationString {
 	pub spans: Vec<ModerationSpan>,
 }
 
-impl<R: Read+LERead> Deserialize<LE, R> for ChatModerationString {
-	fn deserialize(reader: &mut R) -> Res<Self>	{
+impl<R: Read + LERead> Deserialize<LE, R> for ChatModerationString {
+	fn deserialize(reader: &mut R) -> Res<Self> {
 		let _string_okay: bool = LERead::read(reader)?;
 		let _source_id: u16 = LERead::read(reader)?; // unused
 		let request_id = LERead::read(reader)?;
@@ -545,8 +539,8 @@ impl<R: Read+LERead> Deserialize<LE, R> for ChatModerationString {
 	}
 }
 
-impl<'a, W: Write+LEWrite> Serialize<LE, W> for &'a ChatModerationString {
-	fn serialize(self, writer: &mut W) -> Res<()>	{
+impl<'a, W: Write + LEWrite> Serialize<LE, W> for &'a ChatModerationString {
+	fn serialize(self, writer: &mut W) -> Res<()> {
 		LEWrite::write(writer, self.spans.is_empty())?;
 		LEWrite::write(writer, 0u16)?;
 		LEWrite::write(writer, self.request_id)?;

--- a/src/world/gm/client/mod.rs
+++ b/src/world/gm/client/mod.rs
@@ -283,7 +283,7 @@ pub struct EchoStartSkill {
 	pub bitstream: Vec<u8>,
 	pub skill_id: u32, // todo: type
 	#[default(0)]
-	pub skill_handle: u32	
+	pub skill_handle: u32,
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
@@ -795,13 +795,13 @@ pub struct UseItemResult {
 pub struct PetResponse {
 	pub obj_id_pet: ObjId,
 	pub pet_command_type: i32, // todo: type
-	pub response: i32, // todo: type
-	pub type_id: i32, // todo: type
+	pub response: i32,         // todo: type
+	pub type_id: i32,          // todo: type
 }
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct SendActivitySummaryLeaderboardData {
-	pub game_id: i32, // todo: type
+	pub game_id: i32,   // todo: type
 	pub info_type: i32, // todo: type
 	pub leaderboard_data: LuNameValue,
 	pub throttled: bool,
@@ -1388,7 +1388,7 @@ pub struct ChangeIdleFlags {
 
 #[derive(Debug, GameMessage, PartialEq)]
 pub struct NotifyRacingClient {
-#[default(RacingClientNotificationType::Invalid)]
+	#[default(RacingClientNotificationType::Invalid)]
 	pub event_type: RacingClientNotificationType,
 	pub param1: i32,
 	pub param_obj: ObjId,

--- a/src/world/gm/mod.rs
+++ b/src/world/gm/mod.rs
@@ -31,7 +31,7 @@ macro_rules! gm_param {
 				::endio::LEWrite::write(writer, self)
 			}
 		}
-	}
+	};
 }
 
 gm_param!(u8);
@@ -49,7 +49,9 @@ impl GmParam for Vec<u8> {
 		let str_len: u32 = LERead::read(reader)?;
 		let str_len = str_len as usize;
 		let mut vec = Vec::with_capacity(str_len);
-		unsafe { vec.set_len(str_len); }
+		unsafe {
+			vec.set_len(str_len);
+		}
 		Read::read(reader, &mut vec)?;
 		Ok(vec)
 	}
@@ -226,7 +228,7 @@ pub struct MoveItemInInventory {
 	pub obj_id: ObjId,
 	pub inventory_type: InventoryType,
 	pub response_code: i32, // todo: type
-	pub slot: i32, // todo: unsigned?
+	pub slot: i32,          // todo: unsigned?
 }
 
 #[derive(Debug, GameMessage, PartialEq)]

--- a/src/world/lnv.rs
+++ b/src/world/lnv.rs
@@ -27,6 +27,7 @@ pub enum LnvValue {
 }
 
 impl LnvValue {
+	#[rustfmt::skip]
 	fn parse_ty_val(wstr: &LuWStr) -> Self {
 		let string: String = wstr.to_string();
 		let (ty, val) = string.split_at(string.find(":").unwrap());
@@ -47,6 +48,7 @@ impl LnvValue {
 }
 
 impl std::fmt::Debug for LnvValue {
+	#[rustfmt::skip]
 	fn fmt(&self, f: &mut std::fmt::Formatter) -> Result<(), std::fmt::Error> {
 		match self {
 			LnvValue::WString(x) => write!(f, "{:?}", x),
@@ -233,6 +235,7 @@ impl From<&LuNameValue> for LuVarWString<u32> {
 		for (key, value) in key_value {
 			wstr.extend_from_slice(&key);
 			wstr.push(b'='.into());
+			#[rustfmt::skip]
 			let (disc, val_str) = match value {
 				LnvValue::WString(val) => ("0",  val.to_string()),
 				LnvValue::I32    (val) => ("1",  val.to_string()),

--- a/src/world/lnv.rs
+++ b/src/world/lnv.rs
@@ -65,47 +65,69 @@ impl std::fmt::Debug for LnvValue {
 }
 
 impl From<LuVarWString<u32>> for LnvValue {
-	fn from(val: LuVarWString<u32>) -> Self { LnvValue::WString(val) }
+	fn from(val: LuVarWString<u32>) -> Self {
+		LnvValue::WString(val)
+	}
 }
 
 impl From<&str> for LnvValue {
-	fn from(val: &str) -> Self { LnvValue::WString(val.try_into().unwrap()) }
+	fn from(val: &str) -> Self {
+		LnvValue::WString(val.try_into().unwrap())
+	}
 }
 
 impl From<i32> for LnvValue {
-	fn from(val: i32) -> Self { LnvValue::I32(val) }
+	fn from(val: i32) -> Self {
+		LnvValue::I32(val)
+	}
 }
 
 impl From<f32> for LnvValue {
-	fn from(val: f32) -> Self { LnvValue::F32(val) }
+	fn from(val: f32) -> Self {
+		LnvValue::F32(val)
+	}
 }
 
 impl From<f64> for LnvValue {
-	fn from(val: f64) -> Self { LnvValue::F64(val) }
+	fn from(val: f64) -> Self {
+		LnvValue::F64(val)
+	}
 }
 
 impl From<u32> for LnvValue {
-	fn from(val: u32) -> Self { LnvValue::U32(val) }
+	fn from(val: u32) -> Self {
+		LnvValue::U32(val)
+	}
 }
 
 impl From<bool> for LnvValue {
-	fn from(val: bool) -> Self { LnvValue::Bool(val) }
+	fn from(val: bool) -> Self {
+		LnvValue::Bool(val)
+	}
 }
 
 impl From<i64> for LnvValue {
-	fn from(val: i64) -> Self { LnvValue::I64(val) }
+	fn from(val: i64) -> Self {
+		LnvValue::I64(val)
+	}
 }
 
 impl From<u64> for LnvValue {
-	fn from(val: u64) -> Self { LnvValue::U64(val) }
+	fn from(val: u64) -> Self {
+		LnvValue::U64(val)
+	}
 }
 
 impl From<&[u8]> for LnvValue {
-	fn from(val: &[u8]) -> Self { LnvValue::String(val.try_into().unwrap()) }
+	fn from(val: &[u8]) -> Self {
+		LnvValue::String(val.try_into().unwrap())
+	}
 }
 
 impl<const N: usize> From<&[u8; N]> for LnvValue {
-	fn from(val: &[u8; N]) -> Self { LnvValue::String(val.try_into().unwrap()) }
+	fn from(val: &[u8; N]) -> Self {
+		LnvValue::String(val.try_into().unwrap())
+	}
 }
 
 /// A hash map with values being one of multiple possible types.
@@ -156,7 +178,7 @@ impl<R: Read> Deserialize<LE, R> for LuNameValue {
 			assert_eq!(uncomp.len(), uncomp_len as usize);
 			uncomp
 		} else {
-			let mut uncomp = vec![0; len as usize -1];
+			let mut uncomp = vec![0; len as usize - 1];
 			reader.read_exact(&mut uncomp)?;
 			uncomp
 		};
@@ -211,7 +233,7 @@ impl<'a, W: Write> Serialize<LE, W> for &'a LuNameValue {
 impl From<&LuVarWString<u32>> for LuNameValue {
 	fn from(wstr: &LuVarWString<u32>) -> Self {
 		if wstr.is_empty() {
-			return LuNameValue(HashMap::new())
+			return LuNameValue(HashMap::new());
 		}
 		let mut map = HashMap::new();
 		for name_type_val in wstr.split(|c| *c == b'\n'.into()) {

--- a/src/world/server/mail/mod.rs
+++ b/src/world/server/mail/mod.rs
@@ -15,12 +15,12 @@ pub enum Mail {
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
-#[trailing_padding=4]
+#[trailing_padding = 4]
 pub struct CreateRequest {
 	pub subject: LuWString50,
 	pub body: LuWString400,
 	pub receiver_name: LuWString32,
-	#[padding=8] // money: i64, unused
+	#[padding = 8] // money: i64, unused
 	pub attachment_id: ObjId,
 	pub attachment_count: u16,
 	pub locale_id: u16,
@@ -28,20 +28,20 @@ pub struct CreateRequest {
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct ContentCollectRequest {
-	#[padding=4]
+	#[padding = 4]
 	pub mail_id: ObjId,
 	pub receiver_id: ObjId,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct DeleteRequest {
-	#[padding=4]
+	#[padding = 4]
 	pub mail_id: ObjId,
 	pub receiver_id: ObjId,
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
 pub struct MarkAsReadRequest {
-	#[padding=4]
+	#[padding = 4]
 	pub mail_id: ObjId,
 }

--- a/src/world/server/mod.rs
+++ b/src/world/server/mod.rs
@@ -84,6 +84,7 @@ pub struct ClientValidation {
 impl<R: Read+LERead> Deserialize<LE, R> for ClientValidation
 	where   u8: Deserialize<LE, R>,
 	  LuWString33: Deserialize<LE, R> {
+	#[rustfmt::skip]
 	fn deserialize(reader: &mut R) -> Res<Self> {
 		let username         = LERead::read(reader)?;
 		let session_key      = LERead::read(reader)?;

--- a/src/world/server/mod.rs
+++ b/src/world/server/mod.rs
@@ -32,7 +32,7 @@ pub enum LuMessage {
 
 /// All server-received world messages.
 #[derive(Debug, Deserialize, PartialEq, Serialize, VariantTests)]
-#[post_disc_padding=1]
+#[post_disc_padding = 1]
 #[repr(u32)]
 pub enum WorldMessage {
 	ClientValidation(ClientValidation) = 1,
@@ -81,9 +81,11 @@ pub struct ClientValidation {
 	pub fdb_checksum: [u8; 32],
 }
 
-impl<R: Read+LERead> Deserialize<LE, R> for ClientValidation
-	where   u8: Deserialize<LE, R>,
-	  LuWString33: Deserialize<LE, R> {
+impl<R: Read + LERead> Deserialize<LE, R> for ClientValidation
+where
+	u8: Deserialize<LE, R>,
+	LuWString33: Deserialize<LE, R>,
+{
 	#[rustfmt::skip]
 	fn deserialize(reader: &mut R) -> Res<Self> {
 		let username         = LERead::read(reader)?;
@@ -100,9 +102,11 @@ impl<R: Read+LERead> Deserialize<LE, R> for ClientValidation
 	}
 }
 
-impl<'a, W: Write+LEWrite> Serialize<LE, W> for &'a ClientValidation
-	where       u8: Serialize<LE, W>,
-	  &'a LuWString33: Serialize<LE, W> {
+impl<'a, W: Write + LEWrite> Serialize<LE, W> for &'a ClientValidation
+where
+	u8: Serialize<LE, W>,
+	&'a LuWString33: Serialize<LE, W>,
+{
 	fn serialize(self, writer: &mut W) -> Res<()> {
 		LEWrite::write(writer, &self.username)?;
 		LEWrite::write(writer, &self.session_key)?;
@@ -127,7 +131,7 @@ impl<'a, W: Write+LEWrite> Serialize<LE, W> for &'a ClientValidation
 	Respond with [`CharacterCreateResponse`](super::client::CharacterCreateResponse), using the appropriate variant to indicate the result. If the character creation is successful, additionally send a [`CharacterListResponse`](super::client::CharacterListResponse) afterwards with the new character included.
 */
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
-#[trailing_padding=1]
+#[trailing_padding = 1]
 pub struct CharacterCreateRequest {
 	/// The custom name, or blank if the predefined name is to be used.
 	pub char_name: LuWString33,
@@ -137,17 +141,17 @@ pub struct CharacterCreateRequest {
 	pub predef_name_id_2: u32, // todo: enum
 	/// Third part of the predefined name.
 	pub predef_name_id_3: u32, // todo: enum
-	#[padding=9]
+	#[padding = 9]
 	/// Chosen torso color.
 	pub torso_color: u32, // todo: enum
-	#[padding=4]
+	#[padding = 4]
 	/// Chosen legs color.
 	pub legs_color: u32, // todo: enum
 	/// Chosen hair style.
 	pub hair_style: u32, // todo: enum
 	/// Chosen hair color.
 	pub hair_color: u32, // todo: enum
-	#[padding=8]
+	#[padding = 8]
 	/// Chosen eyebrow style.
 	pub eyebrows_style: u32, // todo: enum
 	/// Chosen eye style.
@@ -199,25 +203,23 @@ pub struct GeneralChatMessage {
 	pub message: LuVarWString<u32>,
 }
 
-impl<R: Read+LERead> Deserialize<LE, R> for GeneralChatMessage
-	where   u8: Deserialize<LE, R>,
-	  LuWString33: Deserialize<LE, R> {
+impl<R: Read + LERead> Deserialize<LE, R> for GeneralChatMessage
+where
+	u8: Deserialize<LE, R>,
+	LuWString33: Deserialize<LE, R>,
+{
 	fn deserialize(reader: &mut R) -> Res<Self> {
 		let chat_channel = LERead::read(reader)?;
-		let source_id    = LERead::read(reader)?;
+		let source_id = LERead::read(reader)?;
 		let mut str_len: u32 = LERead::read(reader)?;
 		str_len -= 1;
 		let message = LuVarWString::deser_content(reader, str_len)?;
-		let _: u16       = LERead::read(reader)?;
-		Ok(Self {
-			chat_channel,
-			source_id,
-			message,
-		})
+		let _: u16 = LERead::read(reader)?;
+		Ok(Self { chat_channel, source_id, message })
 	}
 }
 
-impl<'a, W: Write+LEWrite> Serialize<LE, W> for &'a GeneralChatMessage {
+impl<'a, W: Write + LEWrite> Serialize<LE, W> for &'a GeneralChatMessage {
 	fn serialize(self, writer: &mut W) -> Res<()> {
 		LEWrite::write(writer, &self.chat_channel)?;
 		LEWrite::write(writer, self.source_id)?;
@@ -245,7 +247,7 @@ pub struct LevelLoadComplete {
 }
 
 #[derive(Debug, Deserialize, PartialEq, Serialize)]
-#[pre_disc_padding=4]
+#[pre_disc_padding = 4]
 #[repr(u16)]
 pub enum RouteMessage {
 	Chat(ChatMessage) = ServiceId::Chat as u16,


### PR DESCRIPTION
Here's a rustfmt config following the requests in https://github.com/lcdr/lu_packets/pull/5#issuecomment-1416498041. 

I've set the max line length to 1000 to effectively disable automatic wrapping of long lines. It could be adjusted to e.g. 500 to enable it for places like the huge if-statement in capture_parser/main.rs where breaking up long lines might be desired after all.